### PR TITLE
fix: validation관련 ExceptionHandler 수정 완료 #10

### DIFF
--- a/src/main/java/com/ktcloud/daangn/config/ResultCode.java
+++ b/src/main/java/com/ktcloud/daangn/config/ResultCode.java
@@ -2,7 +2,6 @@ package com.ktcloud.daangn.config;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -13,7 +12,8 @@ public enum ResultCode {
     SUCCESS(HttpStatus.OK.value(), "성공"), // 200
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 에러가 발생했습니다"), // 500
     NOT_FOUND(HttpStatus.NOT_FOUND.value(), "요청하신 api를 찾을 수 없습니다."), // 404
-    BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "항목이 올바르지 않습니다"), // 400
+    BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "항목이 올바르지 않습니다"),
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST.value(), "입력 값의 유효성 검사에 실패했습니다."), // 400
     MAIL_ERROR(HttpStatus.BAD_REQUEST.value(), "발급 받은 인증 코드가 만료 되었거나 잘못 되었습니다."),
     INVALID_JSON(HttpStatus.INTERNAL_SERVER_ERROR.value(), "전달된 JSON 형식이 올바르지 않습니다"), // 400
     RUN_TIME_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "런타임 에러"),

--- a/src/main/java/com/ktcloud/daangn/config/exception/CustomerExceptionHandler.java
+++ b/src/main/java/com/ktcloud/daangn/config/exception/CustomerExceptionHandler.java
@@ -16,17 +16,24 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 import java.net.BindException;
 import java.security.SignatureException;
 import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class CustomerExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<BaseResponse<String>> methodArgumentNotValidException(MethodArgumentNotValidException ex) {
-        FieldError fieldError = (FieldError) ex.getBindingResult().getAllErrors().getFirst();
-        String message = fieldError.getField().replaceFirst("_", "") + ": " + fieldError.getDefaultMessage();
+    protected ResponseEntity<BaseResponse<Map<String, String>>> methodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        Map<String, String> validationErrors = ex.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.toMap(
+                        FieldError::getField,
+                        error -> Optional.ofNullable(error.getDefaultMessage()).orElse("유효하지 않은 값입니다."),
+                        (existing, _) -> existing
+                ));
         return ResponseEntity
-                .status(ResultCode.BAD_REQUEST.getStatusCode())
-                .body(new BaseResponse<>(ResultCode.BAD_REQUEST.getStatusCode(), LocalDateTime.now(), message, null));
+                .status(ResultCode.VALIDATION_FAILED.getStatusCode())
+                .body(new BaseResponse<>(ResultCode.VALIDATION_FAILED.getStatusCode(), LocalDateTime.now(), ResultCode.VALIDATION_FAILED.getMessage(), validationErrors));
     }
 
     /// 매개변수 값이 올바르게 처리 되지 않았을때 에러처리
@@ -36,7 +43,7 @@ public class CustomerExceptionHandler {
                 .status(ResultCode.BAD_REQUEST.getStatusCode())
                 .body(new BaseResponse<>(ResultCode.BAD_REQUEST.getStatusCode(), LocalDateTime.now(), ex.getMessage(), null));
     }
-
+    //TODO NOT_FIND 변경
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     protected ResponseEntity<BaseResponse<String>> httpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException ex, HttpServletRequest  req) {
         return ResponseEntity
@@ -46,12 +53,13 @@ public class CustomerExceptionHandler {
 
     
     @ExceptionHandler(InvalidInputException.class)
-    protected ResponseEntity<BaseResponse<String>> apiCustomExeption(InvalidInputException ex) {
+    protected ResponseEntity<BaseResponse<String>> apiCustomException(InvalidInputException ex) {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new BaseResponse<>(ex.getStatusCode(), LocalDateTime.now(), ex.getMessage(), null));
     }
 
+    //TODO 추후 정리 필요 (중복 로직)
     // 404 NOT_FOUND 에러 처리
     @ExceptionHandler(NoHandlerFoundException.class)
     protected ResponseEntity<BaseResponse<String>> handleNotFoundException(NoHandlerFoundException ex) {


### PR DESCRIPTION
validation 관련 ExceptionHandler 수정

기존 반환값이 Valid에서 걸린 값 중 하나만 반환하며, message로만 반환하도록 설정되어 있음

반환값이 Valid에서 걸린 값 전체를 Data에 담아 어떤 항목의 문제인지 반환 할 수 있도록 수정

[참고 자료 1 : MethodArgumentNotValidException](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/MethodArgumentNotValidException.html)
[참고 자료 2 : Optional](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html)
resolved #10