### PR TITLE
Chore/remove explicit versions for testcontainers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ dependencies {
 	//test 환경 dependency
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation platform('org.testcontainers:testcontainers-bom:2.0.4')
-	testImplementation 'org.testcontainers:mysql:1.21.4'
-	testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
+	testImplementation 'org.testcontainers:testcontainers-mysql'
+	testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
 
 	mockitoAgent('org.mockito:mockito-core') {
 		transitive = false

--- a/src/test/java/com/ktcloud/daangn/config/TestContainerConfig.java
+++ b/src/test/java/com/ktcloud/daangn/config/TestContainerConfig.java
@@ -1,10 +1,9 @@
 package com.ktcloud.daangn.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 
 @TestConfiguration(proxyBeanMethods = false)
 public class TestContainerConfig {
@@ -12,6 +11,6 @@ public class TestContainerConfig {
     @Bean
     @ServiceConnection
     public MySQLContainer mySQLContainer(){
-        return new MySQLContainer<>("mysql:8.0");
+        return new MySQLContainer("mysql:9.7");
     }
 }


### PR DESCRIPTION
Testcontainers 의존성 정리 및 deprecated import 수정

변경사항

- testcontainers:mysql 명시적 버전 제거
- testcontainers:junit-jupiter 명시적 버전 제거
- `testcontainerconfig` 불필요 import 삭제
- deprecated된 import 변경
- MySQL 컨테이너 버전 최신화(mysql:9.7)

사유

- BOM에서 호환되는 버전을 자동 관리
- 중복 버전 명시로 인한 충돌 방지
- 의존성 관리 단순화

resolve #28 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **유지보수**
  * 테스트 의존성을 버전 관리 체계에 맞춰 정렬하여 일관성을 개선했습니다.
  * MySQL 테스트 환경을 최신 버전으로 업그레이드하여 호환성을 강화했습니다.
  * 테스트 인프라 설정을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->