### PR TITLE
fix : 응답필드(BaseResponse) 변수명 변경에 따른 채팅 통합테스트 이슈 hotfix

### DIFF
--- a/src/test/java/com/ktcloud/daangn/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/chat/integration/ChatIntegrationTest.java
@@ -92,9 +92,9 @@ class ChatIntegrationTest {
         // 회원 가입 API를 통하지 않고 채팅에 필요한 회원만 준비
         MvcResult enterResult = enterRoom(members, 100L)
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.Data.created").value(true))
+                .andExpect(jsonPath("$.data.created").value(true))
                 .andReturn();
-        Long roomId = readLong(enterResult, "$.Data.roomId");
+        Long roomId = readLong(enterResult, "$.data.roomId");
 
         // HTTP API는 MockMvc로 빠르게 검증하고 메시지 전송 및 브로드캐스트는 실제 STOMP 연결로 확인
         WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
@@ -129,13 +129,13 @@ class ChatIntegrationTest {
             mockMvc.perform(get("/api/v1/chat/messages/{roomId}", roomId)
                             .param("memberId", members.senderId().toString()))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.Data[0].messageId").value(sentMessage.messageId()))
-                    .andExpect(jsonPath("$.Data[0].message").value("hello integration"));
+                    .andExpect(jsonPath("$.data[0].messageId").value(sentMessage.messageId()))
+                    .andExpect(jsonPath("$.data[0].message").value("hello integration"));
 
             enterRoom(members, 100L)
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.Data.roomId").value(roomId))
-                    .andExpect(jsonPath("$.Data.created").value(false));
+                    .andExpect(jsonPath("$.data.roomId").value(roomId))
+                    .andExpect(jsonPath("$.data.created").value(false));
 
             mockMvc.perform(post("/api/v1/chat/rooms/read/{roomId}", roomId)
                             .contentType(MediaType.APPLICATION_JSON)
@@ -145,12 +145,12 @@ class ChatIntegrationTest {
                                     }
                                     """.formatted(members.receiverId())))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.Data.readMessageCount").value(1));
+                    .andExpect(jsonPath("$.data.readMessageCount").value(1));
 
             mockMvc.perform(get("/api/v1/chat/messages/{roomId}", roomId)
                             .param("memberId", members.receiverId().toString()))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.Data[0].unreadCount").value(0));
+                    .andExpect(jsonPath("$.data[0].unreadCount").value(0));
 
             mockMvc.perform(patch("/api/v1/chat/messages/{messageId}", sentMessage.messageId())
                             .contentType(MediaType.APPLICATION_JSON)
@@ -161,8 +161,8 @@ class ChatIntegrationTest {
                                     }
                                     """.formatted(members.senderId())))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.Data.message").value("edited integration"))
-                    .andExpect(jsonPath("$.Data.edited").value(true));
+                    .andExpect(jsonPath("$.data.message").value("edited integration"))
+                    .andExpect(jsonPath("$.data.edited").value(true));
 
             ChatMessageResponseDto editedMessage = pollMessage(messageEvents);
             assertThat(editedMessage.messageId()).isEqualTo(sentMessage.messageId());
@@ -177,8 +177,8 @@ class ChatIntegrationTest {
                                     }
                                     """.formatted(members.senderId())))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.Data.deleted").value(true))
-                    .andExpect(jsonPath("$.Data.message").value("삭제된 메시지입니다."));
+                    .andExpect(jsonPath("$.data.deleted").value(true))
+                    .andExpect(jsonPath("$.data.message").value("삭제된 메시지입니다."));
 
             ChatMessageResponseDto deletedMessage = pollMessage(messageEvents);
             assertThat(deletedMessage.messageId()).isEqualTo(sentMessage.messageId());


### PR DESCRIPTION
BaseResponse의 변수명에 따라 test코드의 오타 수정
- 변수명 data에 맞춰서 수정하는 것으로 에러 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 채팅 통합 테스트 검증 로직 개선으로 API 응답 형식 일관성 강화

---

**참고:** 본 변경사항은 내부 품질 보증 작업입니다. 최종 사용자에게 직접적인 영향은 없습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Gmo-Daangn/server/pull/44)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->