### PR TITLE
docs: Member API 문서화 (#43)

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -16,3 +16,16 @@ include::{snippets}/auth-signup-success/response-fields.adoc[]
 
 === CURL
 include::{snippets}/auth-signup-success/curl-request.adoc[]
+
+== 내정보 조회 성공
+
+=== 요청
+include::{snippets}/member-info-success/http-request.adoc[]
+include::{snippets}/member-info-success/request-headers.adoc[]
+
+=== 응답
+include::{snippets}/member-info-success/http-response.adoc[]
+include::{snippets}/member-info-success/response-fields.adoc[]
+
+=== CURL
+include::{snippets}/member-info-success/curl-request.adoc[]

--- a/src/test/java/com/ktcloud/daangn/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ktcloud/daangn/member/controller/MemberControllerTest.java
@@ -8,20 +8,32 @@ import com.ktcloud.daangn.auth.jwt.JwtTokenProvider;
 import com.ktcloud.daangn.common.valueObject.Address;
 import com.ktcloud.daangn.member.dto.MemberInfoResponseDto;
 import com.ktcloud.daangn.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -32,9 +44,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         JwtAuthenticationEntryPoint.class,
         JwtAccessDeniedHandler.class
 })
+@ExtendWith(RestDocumentationExtension.class)
 class MemberControllerTest {
 
-    @Autowired
     private MockMvc mockMvc;
 
     @MockitoBean
@@ -42,6 +54,14 @@ class MemberControllerTest {
 
     @MockitoBean
     private MemberService memberService;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentation))
+                .apply(springSecurity())
+                .build();
+    }
 
     @Nested
     @DisplayName("내정보 조회")
@@ -65,11 +85,28 @@ class MemberControllerTest {
                     List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))
             );
             //when & then
-            mockMvc.perform(get("/api/v1/members").with(SecurityMockMvcRequestPostProcessors.user(customUser)))
+            mockMvc.perform(get("/api/v1/members")
+                            .with(SecurityMockMvcRequestPostProcessors.user(customUser))
+                            .header("Authorization", "Bearer {accessToken}"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(200))
                     .andExpect(jsonPath("$.data.email").value("test@test.com"))
-                    .andExpect(jsonPath("$.data.nickname").value("테스트"));
+                    .andExpect(jsonPath("$.data.nickname").value("테스트"))
+                    .andDo(document("member-info-success",
+                            requestHeaders(
+                                headerWithName("Authorization").description("Bearer 액세스 토큰")
+                            ),
+                            responseFields(
+                                fieldWithPath("code").description("HTTP 상태 코드"),
+                                fieldWithPath("localDateTime").description("응답시간"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.email").description("이메일"),
+                                fieldWithPath("data.nickname").description("닉네임"),
+                                fieldWithPath("data.address.city").description("시/도"),
+                                fieldWithPath("data.address.district").description("구/군"),
+                                fieldWithPath("data.address.town").description("동/읍/면")
+                            )
+                    ));
         }
         
         @Test


### PR DESCRIPTION
작업 내용
- 내 정보 조회 API 문서화
- `index.adoc` 업데이트

참고 사항
- Auth PR 머지 후 해당 브랜치에 병합 → develop 머지 예정 (`index.adoc` 충돌 방지)

resolve #43 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 주요 변경사항

* **문서화**
  * "내정보 조회 성공" 섹션 추가 및 요청/응답/CURL 예시를 포함한 상세 API 문서 추가

* **테스트**
  * API 문서 자동 생성을 위한 테스트에 REST Docs 통합 설정 추가
  * 성공 응답 시 요청 헤더(Authorization 등)과 응답 필드가 문서화되도록 테스트 출력 구성

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Gmo-Daangn/server/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->