### PR TITLE
Test/k6 test 기본성능 테스트 구현

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -20,7 +20,6 @@
 ## 실행 방법
 
 ```bash
-k6 run k6/scripts/smoke.js
 k6 run k6/scripts/auth-flow.js
 k6 run k6/scripts/rest-read.js
 k6 run k6/scripts/posts.js

--- a/k6/README.md
+++ b/k6/README.md
@@ -1,23 +1,52 @@
-# k6 테스트
+# k6 성능테스트
 
-서버의 주요 API를 실제 실행 환경에서 확인하기 위한 k6 테스트 모음입니다.
+Daangn 서버의 주요 REST API와 실시간 통신 기능을 검증하기 위한 k6 성능 테스트 입니다.
+테스트는 실제 HTTP/WebSocket/SSE 요청을 보내며, 인증 흐름, 게시글 API, 채팅 API, 알림 스트림이 정상 응답과 목표 응답 시간을 만족하는지 확인합니다.
 
-## 실행 전 준비
+## 요구사항
 
 - Spring Boot 서버가 `http://localhost:8080`에서 실행 중이어야 합니다.
-- MySQL 컨테이너가 실행 중이어야 합니다.
+- 서버가 사용하는 MySQL 데이터베이스가 실행 중이어야 합니다.
+- 로컬 환경에 `k6`가 설치되어 있어야 합니다.
+- SSE 테스트(`notification-sse.js`)는 `k6/x/sse` 확장이 포함된 k6 실행 환경이 필요합니다.
 
-## 테스트 목록
+테스트 스크립트는 실행 중 회원, 게시글, 채팅방 데이터를 생성합니다.
 
-- `scripts/smoke.js`: 회원가입, 로그인, 내 정보 조회, 게시글 생성/조회 기본 흐름 확인
-- `scripts/auth-flow.js`: 회원가입, 로그인, JWT 인증 API 성능 확인
-- `scripts/rest-read.js`: 내 정보 조회, 게시글 목록/상세 조회 성능 확인
-- `scripts/posts.js`: 게시글 생성, 상세 조회, 수정, 목록 조회, 삭제 확인
-- `scripts/chat-http.js`: 채팅방 생성, 목록 조회, 메시지 조회, 읽음 처리 확인
-- `scripts/chat-ws.js`: WebSocket/STOMP 연결, 구독, 메시지 발행/수신 확인
-- `scripts/notification-sse.js`: 알림 SSE 연결과 초기 notification 이벤트 수신 확인
+반복 실행 시 테스트 데이터가 누적될 수 있으므로 운영 데이터베이스가 아닌 로컬 또는 전용 테스트 데이터베이스에서 실행하는 것을 권장합니다.
+
+## 폴더 구조
+
+```text
+k6/
+  data/
+    users.json
+  lib/
+    api.js
+  scripts/
+    auth-flow.js
+    rest-read.js
+    posts.js
+    chat-http.js
+    chat-ws.js
+    notification-sse.js
+```
+
+`lib/api.js`에는 테스트에서 공통으로 사용하는 함수가 들어 있습니다. 회원 생성, 로그인, 게시글 생성, 채팅방 입장처럼 여러 스크립트에서 반복되는 준비 작업을 이 파일에서 처리합니다.
+
+## 테스트 목표
+
+| 파일                            | 테스트 목표                   | 주요 검증 범위                                                  | 기본 부하                |
+|-------------------------------|--------------------------|-----------------------------------------------------------|----------------------|
+| `scripts/auth-flow.js`        | 인증 흐름 성능 확인              | 회원가입, 로그인, JWT 인증 후 내 정보 조회                               | 최대 100 VUs까지 ramp-up |
+| `scripts/rest-read.js`        | 읽기 중심 REST API 성능 확인     | 내 정보 조회, 게시글 목록 조회, 게시글 상세 조회                             | 100 VUs / 1분         |
+| `scripts/posts.js`            | 게시글 CRUD 흐름 확인           | 게시글 생성, 상세 조회, 수정, 목록 조회, 삭제                              | 100 VUs / 1분         |
+| `scripts/chat-http.js`        | 채팅 REST API 성능 확인        | 채팅방 목록 조회, 메시지 조회, 읽음 처리                                  | 100 VUs / 1분         |
+| `scripts/chat-ws.js`          | 채팅 WebSocket/STOMP 흐름 확인 | WebSocket handshake, STOMP connect/subscribe/send, 메시지 수신 | 100 VUs / 1분         |
+| `scripts/notification-sse.js` | 알림 SSE 연결 확인             | SSE 연결, 초기 `notification` 이벤트 수신, 알림 목록 조회                | 100 VUs / 1분         |
 
 ## 실행 방법
+
+각 스크립트는 프로젝트 루트에서 다음과 같이 실행합니다.
 
 ```bash
 k6 run k6/scripts/auth-flow.js
@@ -27,23 +56,53 @@ k6 run k6/scripts/chat-http.js
 k6 run k6/scripts/chat-ws.js
 ```
 
-SSE 테스트는 `k6/x/sse` 확장이 필요합니다.
+SSE 테스트는 `k6/x/sse` 확장이 가능한 실행 환경에서 실행합니다.
 
 ```bash
 k6 run k6/scripts/notification-sse.js
 ```
 
-## 설정 변경
+## Configuration
 
-VUS, duration, timeout 값은 각 스크립트 상단의 상수에서 수정합니다.
+기본 서버 주소와 테스트 계정 기본값은 `k6/lib/api.js`에서 관리합니다.
+
+```js
+export const BASE_URL = 'http://localhost:8080';
+export const DEFAULT_PASSWORD = 'password1234';
+```
+
+부하 규모와 실행 시간은 각 스크립트 상단의 상수로 조정합니다.
 
 ```js
 const TARGET_VUS = 100;
 const TEST_DURATION = '1m';
 ```
 
-## 참고
+현재 스크립트는 환경 변수 주입 없이 파일 안의 상수를 기준으로 실행되도록 구성되어 있습니다.
 
-- 테스트는 실행 중 회원, 게시글, 채팅방 데이터를 생성합니다.
-- 반복 실행 시 로컬 DB에 테스트 데이터가 쌓일 수 있습니다.
-- 현재 SSE 테스트는 실제 알림 발행이 아니라 구독 성공 시 내려오는 초기 이벤트를 검증합니다.
+## Thresholds
+
+테스트는 k6 threshold를 통해 기본 성공 기준을 검증합니다.
+
+- `checks`: 주요 응답 검증 성공률이 99%를 초과해야 합니다.
+- `http_req_failed`: HTTP 실패율은 스크립트에 따라 1% 또는 2% 미만이어야 합니다.
+- `http_req_duration`: REST 요청의 p95 응답 시간은 700ms 또는 1000ms 미만이어야 합니다.
+- `ws_connecting`: WebSocket 연결 p95 시간은 1000ms 미만이어야 합니다.
+- `ws_session_duration`: WebSocket 세션 p95 시간은 15000ms 미만이어야 합니다.
+- `sse_event`: SSE 테스트에서 이벤트가 1건 이상 수신되어야 합니다.
+
+`rest-read.js`는 조회 API만 별도 태그(`member_info`, `post_list`, `post_detail`)로 나누어 p95 700ms 기준을 적용합니다.
+
+`chat-http.js`는 채팅 REST API를 별도 태그(`chat_room_list`, `chat_message_list`, `chat_room_read`)로 나누어 p95 1000ms 기준을 적용합니다.
+
+나머지 REST 흐름 테스트는 생성, 수정, 삭제 같은 쓰기 작업을 포함하므로 p95 1000ms 기준을 사용합니다.
+
+## Notes
+
+- `auth-flow.js`, `posts.js`, `chat-ws.js`, `notification-sse.js`는 각 반복에서 필요한 테스트 데이터를 직접 생성합니다.
+- `rest-read.js`는 `setup()` 단계에서 게시글 데이터를 미리 생성한 뒤 읽기 API를 반복 호출합니다.
+- `chat-http.js`는 `setup()` 단계에서 `TARGET_VUS` 수만큼 채팅방 풀을 미리 생성한 뒤 채팅 REST API를 반복 호출합니다.
+- `chat-ws.js`는 STOMP 프레임을 문자열로 직접 구성합니다. k6 기본 WebSocket API가 STOMP 전용 클라이언트를 제공하지 않기 때문에, 서버가 기대하는 STOMP wire format에
+  맞춰 `CONNECT`, `SUBSCRIBE`, `SEND`, `DISCONNECT` 프레임을 전송합니다.
+- `notification-sse.js`는 현재 SSE 연결과 초기 `notification` 이벤트 수신을 검증합니다. 실제 알림 발행까지 포함한 end-to-end 검증은 알림을 발생시킬 수 있는 별도 API나
+  테스트 트리거가 필요합니다.

--- a/k6/README.md
+++ b/k6/README.md
@@ -1,0 +1,54 @@
+# k6 테스트
+
+서버의 주요 API를 실제 실행 환경에서 확인하기 위한 k6 테스트 모음입니다.
+
+## 실행 전 준비
+
+- Spring Boot 서버가 `http://localhost:8080`에서 실행 중이어야 합니다.
+- MySQL 컨테이너가 실행 중이어야 합니다.
+
+```bash
+openssl rand -base64 32
+```
+
+## 테스트 목록
+
+- `scripts/smoke.js`: 회원가입, 로그인, 내 정보 조회, 게시글 생성/조회 기본 흐름 확인
+- `scripts/auth-flow.js`: 회원가입, 로그인, JWT 인증 API 성능 확인
+- `scripts/rest-read.js`: 내 정보 조회, 게시글 목록/상세 조회 성능 확인
+- `scripts/posts.js`: 게시글 생성, 상세 조회, 수정, 목록 조회, 삭제 확인
+- `scripts/chat-http.js`: 채팅방 생성, 목록 조회, 메시지 조회, 읽음 처리 확인
+- `scripts/chat-ws.js`: WebSocket/STOMP 연결, 구독, 메시지 발행/수신 확인
+- `scripts/notification-sse.js`: 알림 SSE 연결과 초기 notification 이벤트 수신 확인
+
+## 실행 방법
+
+```bash
+k6 run k6/scripts/smoke.js
+k6 run k6/scripts/auth-flow.js
+k6 run k6/scripts/rest-read.js
+k6 run k6/scripts/posts.js
+k6 run k6/scripts/chat-http.js
+k6 run k6/scripts/chat-ws.js
+```
+
+SSE 테스트는 `k6/x/sse` 확장이 필요합니다.
+
+```bash
+k6 run k6/scripts/notification-sse.js
+```
+
+## 설정 변경
+
+VUS, duration, timeout 값은 각 스크립트 상단의 상수에서 수정합니다.
+
+```js
+const TARGET_VUS = 100;
+const TEST_DURATION = '1m';
+```
+
+## 참고
+
+- 테스트는 실행 중 회원, 게시글, 채팅방 데이터를 생성합니다.
+- 반복 실행 시 로컬 DB에 테스트 데이터가 쌓일 수 있습니다.
+- 현재 SSE 테스트는 실제 알림 발행이 아니라 구독 성공 시 내려오는 초기 이벤트를 검증합니다.

--- a/k6/README.md
+++ b/k6/README.md
@@ -7,10 +7,6 @@
 - Spring Boot 서버가 `http://localhost:8080`에서 실행 중이어야 합니다.
 - MySQL 컨테이너가 실행 중이어야 합니다.
 
-```bash
-openssl rand -base64 32
-```
-
 ## 테스트 목록
 
 - `scripts/smoke.js`: 회원가입, 로그인, 내 정보 조회, 게시글 생성/조회 기본 흐름 확인

--- a/k6/data/users.json
+++ b/k6/data/users.json
@@ -1,0 +1,6 @@
+[
+  {
+    "email": "k6-seed-user@example.com",
+    "password": "password1234"
+  }
+]

--- a/k6/lib/api.js
+++ b/k6/lib/api.js
@@ -40,10 +40,10 @@ export function signupUser(email = uniqueEmail(), password = DEFAULT_PASSWORD) {
         },
     }), jsonHeaders());
 
-    check(response, {
+    requireChecks(response, {
         'signup status is 200': (r) => r.status === 200,
         'signup returns member id': (r) => extractMemberId(r) > 0,
-    });
+    }, 'signup');
 
     return {
         email,
@@ -59,10 +59,10 @@ export function loginUser(email, password = DEFAULT_PASSWORD) {
         password,
     }), jsonHeaders());
 
-    check(response, {
+    requireChecks(response, {
         'login status is 200': (r) => r.status === 200,
         'login returns access token': (r) => !!responseValue(r, 'data.accessToken'),
-    });
+    }, 'login');
 
     const grantType = responseValue(response, 'data.grantType') || 'Bearer';
     const accessToken = responseValue(response, 'data.accessToken');
@@ -102,10 +102,10 @@ export function createPost(memberId, overrides = {}) {
         memberId,
     }), jsonHeaders());
 
-    check(response, {
+    requireChecks(response, {
         'create post status is 200': (r) => r.status === 200,
         'create post returns post id': (r) => Number(responseValue(r, 'data.postId')) > 0,
-    });
+    }, 'create post');
 
     return {
         postId: Number(responseValue(response, 'data.postId')),
@@ -120,10 +120,10 @@ export function enterChatRoom(memberId, targetMemberId, productId) {
         productId,
     }), jsonHeaders());
 
-    check(response, {
+    requireChecks(response, {
         'chat room enter status is 200': (r) => r.status === 200,
         'chat room id exists': (r) => Number(responseValue(r, 'data.roomId')) > 0,
-    });
+    }, 'chat room enter');
 
     return {
         roomId: Number(responseValue(response, 'data.roomId')),
@@ -147,5 +147,12 @@ export function responseValue(response, path) {
         return response.json(path);
     } catch (_error) {
         return undefined;
+    }
+}
+
+function requireChecks(response, checks, label) {
+    const passed = check(response, checks);
+    if (!passed) {
+        fail(`${label} failed: status=${response.status}`);
     }
 }

--- a/k6/lib/api.js
+++ b/k6/lib/api.js
@@ -1,0 +1,153 @@
+import http from 'k6/http';
+import {check, fail} from 'k6';
+
+// 테스트 대상 서버 주소입니다.
+export const BASE_URL = 'http://localhost:8080';
+export const DEFAULT_PASSWORD = 'password1234';
+
+const JSON_HEADERS = {
+    'Content-Type': 'application/json',
+};
+
+export function jsonHeaders(extraHeaders = {}) {
+    return {
+        headers: {
+            ...JSON_HEADERS,
+            ...extraHeaders,
+        },
+    };
+}
+
+export function uniqueEmail(prefix = 'k6-user') {
+    // 회원가입 시 중복 이메일처리 방지를 위해 랜덤으로 새 이메일을 생성.
+    const vu = typeof __VU === 'undefined' ? 'setup' : __VU;
+    const iter = typeof __ITER === 'undefined' ? 0 : __ITER;
+    const suffix = Math.random().toString(36).slice(2, 10);
+
+    return `${prefix}-${Date.now()}-${vu}-${iter}-${suffix}@test.com`;
+}
+
+export function signupUser(email = uniqueEmail(), password = DEFAULT_PASSWORD) {
+    const nickname = email.split('@')[0];
+    const response = http.post(`${BASE_URL}/api/v1/auth`, JSON.stringify({
+        email,
+        nickname,
+        password,
+        address: {
+            city: 'Seoul',
+            district: 'Gangnam-gu',
+            town: 'Yeoksam-dong',
+        },
+    }), jsonHeaders());
+
+    check(response, {
+        'signup status is 200': (r) => r.status === 200,
+        'signup returns member id': (r) => extractMemberId(r) > 0,
+    });
+
+    return {
+        email,
+        password,
+        memberId: extractMemberId(response),
+        response,
+    };
+}
+
+export function loginUser(email, password = DEFAULT_PASSWORD) {
+    const response = http.post(`${BASE_URL}/api/v1/auth/login`, JSON.stringify({
+        email,
+        password,
+    }), jsonHeaders());
+
+    check(response, {
+        'login status is 200': (r) => r.status === 200,
+        'login returns access token': (r) => !!responseValue(r, 'data.accessToken'),
+    });
+
+    const grantType = responseValue(response, 'data.grantType') || 'Bearer';
+    const accessToken = responseValue(response, 'data.accessToken');
+
+    return {
+        grantType,
+        accessToken,
+        authorization: `${grantType} ${accessToken}`,
+        response,
+    };
+}
+
+export function createMember(prefix = 'k6-user') {
+    // 대부분의 시나리오가 인증된 회원과 DB memberId를 함께 필요로 합니다.
+    const user = signupUser(uniqueEmail(prefix));
+    if (!user.memberId) {
+        fail('signup succeeded without a parseable member id');
+    }
+
+    return {
+        ...user,
+        token: loginUser(user.email, user.password),
+    };
+}
+
+export function authHeaders(token) {
+    // 로그인 응답의 grantType/accessToken 형식에 맞춰 인증 헤더를 만듭니다.
+    return jsonHeaders({
+        Authorization: token.authorization,
+    });
+}
+
+export function createPost(memberId, overrides = {}) {
+    const response = http.post(`${BASE_URL}/api/v1/posts`, JSON.stringify({
+        title: overrides.title || `k6 test post ${Date.now()}`,
+        content: overrides.content || 'Created by k6 smoke/performance scripts.',
+        price: overrides.price ?? 10000,
+        memberId,
+    }), jsonHeaders());
+
+    check(response, {
+        'create post status is 200': (r) => r.status === 200,
+        'create post returns post id': (r) => Number(responseValue(r, 'data.postId')) > 0,
+    });
+
+    return {
+        postId: Number(responseValue(response, 'data.postId')),
+        response,
+    };
+}
+
+export function enterChatRoom(memberId, targetMemberId, productId) {
+    const response = http.post(`${BASE_URL}/api/v1/chat/rooms/enter`, JSON.stringify({
+        memberId,
+        targetMemberId,
+        productId,
+    }), jsonHeaders());
+
+    check(response, {
+        'chat room enter status is 200': (r) => r.status === 200,
+        'chat room id exists': (r) => Number(responseValue(r, 'data.roomId')) > 0,
+    });
+
+    return {
+        roomId: Number(responseValue(response, 'data.roomId')),
+        response,
+    };
+}
+
+function extractMemberId(response) {
+    // 현재 회원가입 응답은 구조화된 ID가 아니라 메시지 문자열로 ID를 돌려줍니다.
+    const message = responseValue(response, 'data');
+    if (typeof message !== 'string') {
+        return 0;
+    }
+
+    const match = message.match(/ID\s*:\s*(\d+)/);
+    return match ? Number(match[1]) : 0;
+}
+
+export function responseValue(response, path) {
+    // 네트워크 실패처럼 body가 비는 경우에도 테스트가 터지지 않고 check 실패로 남게 합니다.
+    try {
+        return response.json(path);
+    } catch (_error) {
+        return undefined;
+    }
+}

--- a/k6/lib/api.js
+++ b/k6/lib/api.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import {check, fail} from 'k6';
 
-// 테스트 대상 서버 주소입니다.
+// 테스트 대상 서버 주소
 export const BASE_URL = 'http://localhost:8080';
 export const DEFAULT_PASSWORD = 'password1234';
 
@@ -19,7 +19,7 @@ export function jsonHeaders(extraHeaders = {}) {
 }
 
 export function uniqueEmail(prefix = 'k6-user') {
-    // 회원가입 시 중복 이메일처리 방지를 위해 랜덤으로 새 이메일을 생성.
+    // 회원가입 시 중복 이메일처리 방지를 위해 랜덤으로 새 이메일을 생성
     const vu = typeof __VU === 'undefined' ? 'setup' : __VU;
     const iter = typeof __ITER === 'undefined' ? 0 : __ITER;
     const suffix = Math.random().toString(36).slice(2, 10);
@@ -76,7 +76,6 @@ export function loginUser(email, password = DEFAULT_PASSWORD) {
 }
 
 export function createMember(prefix = 'k6-user') {
-    // 대부분의 시나리오가 인증된 회원과 DB memberId를 함께 필요로 합니다.
     const user = signupUser(uniqueEmail(prefix));
     if (!user.memberId) {
         fail('signup succeeded without a parseable member id');
@@ -89,7 +88,7 @@ export function createMember(prefix = 'k6-user') {
 }
 
 export function authHeaders(token) {
-    // 로그인 응답의 grantType/accessToken 형식에 맞춰 인증 헤더를 만듭니다.
+    // 로그인 응답의 grantType/accessToken 형식에 맞춰 인증 헤더를 생성
     return jsonHeaders({
         Authorization: token.authorization,
     });
@@ -133,7 +132,6 @@ export function enterChatRoom(memberId, targetMemberId, productId) {
 }
 
 function extractMemberId(response) {
-    // 현재 회원가입 응답은 구조화된 ID가 아니라 메시지 문자열로 ID를 돌려줍니다.
     const message = responseValue(response, 'data');
     if (typeof message !== 'string') {
         return 0;
@@ -144,7 +142,7 @@ function extractMemberId(response) {
 }
 
 export function responseValue(response, path) {
-    // 네트워크 실패처럼 body가 비는 경우에도 테스트가 터지지 않고 check 실패로 남게 합니다.
+    // 네트워크 실패처럼 body가 비는 경우에도 테스트가 터지지 않고 check 실패로 처리
     try {
         return response.json(path);
     } catch (_error) {

--- a/k6/scripts/auth-flow.js
+++ b/k6/scripts/auth-flow.js
@@ -1,0 +1,37 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+import {authHeaders, BASE_URL, createMember} from '../lib/api.js';
+
+const TARGET_VUS = 100;
+const RAMP_UP = '30s';
+const STEADY = '1m';
+const RAMP_DOWN = '30s';
+
+export const options = {
+    scenarios: {
+        auth_flow: {
+            executor: 'ramping-vus',
+            stages: [
+                {duration: RAMP_UP, target: TARGET_VUS},
+                {duration: STEADY, target: TARGET_VUS},
+                {duration: RAMP_DOWN, target: 0},
+            ],
+        },
+    },
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        http_req_duration: ['p(95)<1000'],
+        checks: ['rate>0.99'],
+    },
+};
+
+export default function () {
+    const user = createMember('k6-auth');
+
+    const me = http.get(`${BASE_URL}/api/v1/members`, authHeaders(user.token));
+    check(me, {
+        'authenticated member info status is 200': (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/k6/scripts/chat-http.js
+++ b/k6/scripts/chat-http.js
@@ -4,6 +4,7 @@ import {BASE_URL, createMember, createPost, enterChatRoom, jsonHeaders} from '..
 
 const TARGET_VUS = 100;
 const TEST_DURATION = '1m';
+const CHAT_ROOM_POOL_SIZE = TARGET_VUS;
 
 export const options = {
     scenarios: {
@@ -14,34 +15,63 @@ export const options = {
         },
     },
     thresholds: {
-        http_req_failed: ['rate<0.02'],
-        http_req_duration: ['p(95)<1000'],
         checks: ['rate>0.99'],
+        http_req_failed: ['rate<0.02'],
+        'http_req_duration{endpoint:chat_room_list}': ['p(95)<1000'],
+        'http_req_duration{endpoint:chat_message_list}': ['p(95)<1000'],
+        'http_req_duration{endpoint:chat_room_read}': ['p(95)<1000'],
     },
 };
 
-export default function () {
-    const seller = createMember('k6-seller');
-    const buyer = createMember('k6-buyer');
-    const post = createPost(seller.memberId, {
-        title: `k6 chat product ${__VU}-${__ITER}`,
+export function setup() {
+    const rooms = [];
+
+    for (let index = 0; index < CHAT_ROOM_POOL_SIZE; index += 1) {
+        const seller = createMember('k6-chat-seller');
+        const buyer = createMember('k6-chat-buyer');
+        const post = createPost(seller.memberId, {
+            title: `k6 chat product ${index}`,
+        });
+        const room = enterChatRoom(buyer.memberId, seller.memberId, post.postId);
+
+        rooms.push({
+            buyerId: buyer.memberId,
+            roomId: room.roomId,
+        });
+    }
+
+    return {rooms};
+}
+
+export default function (data) {
+    const room = data.rooms[(__VU - 1) % data.rooms.length];
+
+    const rooms = http.get(`${BASE_URL}/api/v1/chat/rooms?memberId=${room.buyerId}`, {
+        tags: {
+            endpoint: 'chat_room_list',
+        },
     });
-
-    const room = enterChatRoom(buyer.memberId, seller.memberId, post.postId);
-
-    const rooms = http.get(`${BASE_URL}/api/v1/chat/rooms?memberId=${buyer.memberId}`);
     check(rooms, {
         'chat room list status is 200': (r) => r.status === 200,
     });
 
-    const messages = http.get(`${BASE_URL}/api/v1/chat/messages/${room.roomId}?memberId=${buyer.memberId}`);
+    const messages = http.get(`${BASE_URL}/api/v1/chat/messages/${room.roomId}?memberId=${room.buyerId}`, {
+        tags: {
+            endpoint: 'chat_message_list',
+        },
+    });
     check(messages, {
         'chat messages status is 200': (r) => r.status === 200,
     });
 
     const read = http.post(`${BASE_URL}/api/v1/chat/rooms/read/${room.roomId}`, JSON.stringify({
-        memberId: buyer.memberId,
-    }), jsonHeaders());
+        memberId: room.buyerId,
+    }), {
+        ...jsonHeaders(),
+        tags: {
+            endpoint: 'chat_room_read',
+        },
+    });
 
     check(read, {
         'chat room read status is 200': (r) => r.status === 200,

--- a/k6/scripts/chat-http.js
+++ b/k6/scripts/chat-http.js
@@ -1,0 +1,51 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+import {BASE_URL, createMember, createPost, enterChatRoom, jsonHeaders} from '../lib/api.js';
+
+const TARGET_VUS = 100;
+const TEST_DURATION = '1m';
+
+export const options = {
+    scenarios: {
+        chat_http: {
+            executor: 'constant-vus',
+            vus: TARGET_VUS,
+            duration: TEST_DURATION,
+        },
+    },
+    thresholds: {
+        http_req_failed: ['rate<0.02'],
+        http_req_duration: ['p(95)<1000'],
+        checks: ['rate>0.99'],
+    },
+};
+
+export default function () {
+    const seller = createMember('k6-seller');
+    const buyer = createMember('k6-buyer');
+    const post = createPost(seller.memberId, {
+        title: `k6 chat product ${__VU}-${__ITER}`,
+    });
+
+    const room = enterChatRoom(buyer.memberId, seller.memberId, post.postId);
+
+    const rooms = http.get(`${BASE_URL}/api/v1/chat/rooms?memberId=${buyer.memberId}`);
+    check(rooms, {
+        'chat room list status is 200': (r) => r.status === 200,
+    });
+
+    const messages = http.get(`${BASE_URL}/api/v1/chat/messages/${room.roomId}?memberId=${buyer.memberId}`);
+    check(messages, {
+        'chat messages status is 200': (r) => r.status === 200,
+    });
+
+    const read = http.post(`${BASE_URL}/api/v1/chat/rooms/read/${room.roomId}`, JSON.stringify({
+        memberId: buyer.memberId,
+    }), jsonHeaders());
+
+    check(read, {
+        'chat room read status is 200': (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/k6/scripts/chat-ws.js
+++ b/k6/scripts/chat-ws.js
@@ -90,7 +90,7 @@ export default function () {
 }
 
 function stompFrame(command, headers = {}, body = '') {
-    // Spring STOMP 엔드포인트는 null byte로 끝나는 프레임을 기대합니다.
+    // Spring STOMP 문자열 포맷을 직접 만들어서 테스트 진행
     const headerLines = Object.entries(headers)
         .map(([key, value]) => `${key}:${value}`)
         .join('\n');

--- a/k6/scripts/chat-ws.js
+++ b/k6/scripts/chat-ws.js
@@ -35,11 +35,12 @@ export default function () {
     const expectedMessage = `k6 websocket message ${__VU}-${__ITER}-${Date.now()}`;
 
     const url = BASE_URL.replace(/^http/, 'ws') + '/api/ws-stomp';
+    const stompHost = stompHostFromBaseUrl(BASE_URL);
     const response = ws.connect(url, {}, (socket) => {
         socket.on('open', () => {
             socket.send(stompFrame('CONNECT', {
                 'accept-version': '1.2',
-                host: 'localhost',
+                host: stompHost,
             }));
         });
 
@@ -94,6 +95,12 @@ function stompFrame(command, headers = {}, body = '') {
     const headerLines = Object.entries(headers)
         .map(([key, value]) => `${key}:${value}`)
         .join('\n');
+    const headerBlock = headerLines ? `${headerLines}\n` : '';
 
-    return `${command}\n${headerLines}\n\n${body}\x00`;
+    return `${command}\n${headerBlock}\n${body}\x00`;
+}
+
+function stompHostFromBaseUrl(baseUrl) {
+    // BASE_URL이 로컬이 아닌 환경을 가리켜도 STOMP host 헤더가 접속 대상과 맞도록 호스트를 추출
+    return baseUrl.replace(/^https?:\/\//, '').split('/')[0];
 }

--- a/k6/scripts/chat-ws.js
+++ b/k6/scripts/chat-ws.js
@@ -1,0 +1,99 @@
+import ws from 'k6/ws';
+import {check, sleep} from 'k6';
+import {BASE_URL, createMember, createPost, enterChatRoom} from '../lib/api.js';
+
+const TARGET_VUS = 100;
+const TEST_DURATION = '1m';
+const SEND_DELAY_MS = 100;
+const RECEIVE_TIMEOUT_MS = 5000;
+
+export const options = {
+    scenarios: {
+        chat_ws: {
+            executor: 'constant-vus',
+            vus: TARGET_VUS,
+            duration: TEST_DURATION,
+        },
+    },
+    thresholds: {
+        checks: ['rate>0.99'],
+        ws_connecting: ['p(95)<1000'],
+        ws_session_duration: ['p(95)<15000'],
+    },
+};
+
+export default function () {
+    const seller = createMember('k6-ws-seller');
+    const buyer = createMember('k6-ws-buyer');
+    const post = createPost(seller.memberId);
+    const room = enterChatRoom(buyer.memberId, seller.memberId, post.postId);
+
+    let stompConnected = false;
+    let messageReceived = false;
+    let errorFrameReceived = false;
+    const subscriptionId = `sub-${__VU}-${__ITER}`;
+    const expectedMessage = `k6 websocket message ${__VU}-${__ITER}-${Date.now()}`;
+
+    const url = BASE_URL.replace(/^http/, 'ws') + '/api/ws-stomp';
+    const response = ws.connect(url, {}, (socket) => {
+        socket.on('open', () => {
+            socket.send(stompFrame('CONNECT', {
+                'accept-version': '1.2',
+                host: 'localhost',
+            }));
+        });
+
+        socket.on('message', (message) => {
+            if (message.startsWith('CONNECTED')) {
+                stompConnected = true;
+                socket.send(stompFrame('SUBSCRIBE', {
+                    id: subscriptionId,
+                    destination: `/sub/chat/rooms/${room.roomId}/messages`,
+                }));
+
+                socket.setTimeout(() => {
+                    socket.send(stompFrame('SEND', {
+                        destination: `/pub/chat/rooms/${room.roomId}/messages`,
+                        'content-type': 'application/json',
+                    }, JSON.stringify({
+                        memberId: buyer.memberId,
+                        message: expectedMessage,
+                    })));
+                }, SEND_DELAY_MS);
+            }
+
+            if (message.startsWith('MESSAGE') && message.includes(expectedMessage)) {
+                messageReceived = true;
+                socket.send(stompFrame('DISCONNECT', {}));
+                socket.close();
+            }
+
+            if (message.startsWith('ERROR')) {
+                errorFrameReceived = true;
+                socket.close();
+            }
+        });
+
+        socket.setTimeout(() => {
+            socket.close();
+        }, RECEIVE_TIMEOUT_MS);
+    });
+
+    check(response, {
+        'websocket handshake status is 101': (r) => r && r.status === 101,
+        'stomp connected': () => stompConnected,
+        'stomp message received from subscription': () => messageReceived,
+        'stomp error frame was not received': () => !errorFrameReceived,
+    });
+
+    sleep(1);
+}
+
+function stompFrame(command, headers = {}, body = '') {
+    // Spring STOMP 엔드포인트는 null byte로 끝나는 프레임을 기대합니다.
+    const headerLines = Object.entries(headers)
+        .map(([key, value]) => `${key}:${value}`)
+        .join('\n');
+
+    return `${command}\n${headerLines}\n\n${body}\x00`;
+}

--- a/k6/scripts/notification-sse.js
+++ b/k6/scripts/notification-sse.js
@@ -1,0 +1,91 @@
+import http from 'k6/http';
+import sse from 'k6/x/sse';
+import {check, sleep} from 'k6';
+import {BASE_URL, createMember} from '../lib/api.js';
+
+const TARGET_VUS = 100;
+const TEST_DURATION = '1m';
+
+export const options = {
+    scenarios: {
+        notification_sse: {
+            executor: 'constant-vus',
+            vus: TARGET_VUS,
+            duration: TEST_DURATION,
+        },
+    },
+    thresholds: {
+        checks: ['rate>0.99'],
+        http_req_failed: ['rate<0.01'],
+        http_req_duration: ['p(95)<1000'],
+        sse_event: ['count>0'],
+    },
+};
+
+export default function () {
+    const user = createMember('k6-notification-sse');
+    let opened = false;
+    let notificationEventReceived = false;
+    let expectedConnectMessageReceived = false;
+    let errorReceived = false;
+
+    // 기본 k6 http 모듈은 SSE 이벤트 스트림을 다루기 어려워 k6/x/sse 확장을 사용
+    const response = sse.open(`${BASE_URL}/api/v1/notification/sse?memberId=${user.memberId}`, {
+        method: 'GET',
+        headers: {
+            Accept: 'text/event-stream',
+        },
+        tags: {
+            endpoint: 'notification_sse',
+        },
+    }, (client) => {
+        client.on('open', () => {
+            opened = true;
+        });
+
+        client.on('event', (event) => {
+            if (event.name === 'notification') {
+                notificationEventReceived = true;
+            }
+
+            // 초기 연결 성공 이벤트의 receiverId를 검증
+            if (event.data && event.data.includes(`receiverId=${user.memberId}`)) {
+                expectedConnectMessageReceived = true;
+            }
+
+            client.close();
+        });
+
+        client.on('error', () => {
+            errorReceived = true;
+            client.close();
+        });
+
+    });
+
+    check(response, {
+        'sse status is 200': (r) => r && r.status === 200,
+        'sse content type is event-stream': (r) => {
+            const contentType = r && r.headers && r.headers['Content-Type'];
+            return Array.isArray(contentType)
+                ? contentType.some((value) => value.includes('text/event-stream'))
+                : String(contentType || '').includes('text/event-stream');
+        },
+        'sse open event occurred': () => opened,
+        'sse notification event received': () => notificationEventReceived,
+        'sse connect message has receiver id': () => expectedConnectMessageReceived,
+        'sse error was not received': () => !errorReceived,
+    });
+
+    const notifications = http.get(`${BASE_URL}/api/v1/notification?memberId=${user.memberId}`, {
+        tags: {
+            endpoint: 'notification_list',
+        },
+    });
+
+    check(notifications, {
+        'notification list status is 200': (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/k6/scripts/posts.js
+++ b/k6/scripts/posts.js
@@ -1,0 +1,58 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+import {BASE_URL, createMember, createPost, jsonHeaders} from '../lib/api.js';
+
+const TARGET_VUS = 100;
+const TEST_DURATION = '1m';
+
+export const options = {
+    scenarios: {
+        post_crud: {
+            executor: 'constant-vus',
+            vus: TARGET_VUS,
+            duration: TEST_DURATION,
+        },
+    },
+    thresholds: {
+        http_req_failed: ['rate<0.02'],
+        http_req_duration: ['p(95)<1000'],
+        checks: ['rate>0.99'],
+    },
+};
+
+export default function () {
+    const user = createMember('k6-posts');
+    const post = createPost(user.memberId, {
+        title: `k6 post ${__VU}-${__ITER}`,
+        price: 5000 + __ITER,
+    });
+
+    const detail = http.get(`${BASE_URL}/api/v1/posts/${post.postId}`);
+    check(detail, {
+        'post detail status is 200': (r) => r.status === 200,
+    });
+
+    const update = http.put(`${BASE_URL}/api/v1/posts/${post.postId}`, JSON.stringify({
+        title: `k6 updated post ${__VU}-${__ITER}`,
+        content: 'Updated by k6.',
+        price: 7000 + __ITER,
+        memberId: user.memberId,
+        status: 'FOR_SALE',
+    }), jsonHeaders());
+
+    check(update, {
+        'post update status is 200': (r) => r.status === 200,
+    });
+
+    const list = http.get(`${BASE_URL}/api/v1/posts?page=0&size=10`);
+    check(list, {
+        'post list status is 200': (r) => r.status === 200,
+    });
+
+    const remove = http.del(`${BASE_URL}/api/v1/posts/${post.postId}?memberId=${user.memberId}`);
+    check(remove, {
+        'post delete status is 200': (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/k6/scripts/rest-read.js
+++ b/k6/scripts/rest-read.js
@@ -1,0 +1,79 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+import {BASE_URL, createMember, createPost} from '../lib/api.js';
+
+const TARGET_VUS = 100;
+const TEST_DURATION = '1m';
+const SEED_POSTS = 30;
+
+export const options = {
+    scenarios: {
+        rest_read: {
+            executor: 'constant-vus',
+            vus: TARGET_VUS,
+            duration: TEST_DURATION,
+        },
+    },
+    thresholds: {
+        checks: ['rate>0.99'],
+        http_req_failed: ['rate<0.01'],
+        'http_req_duration{endpoint:member_info}': ['p(95)<700'],
+        'http_req_duration{endpoint:post_list}': ['p(95)<700'],
+        'http_req_duration{endpoint:post_detail}': ['p(95)<700'],
+    },
+};
+
+export function setup() {
+    const owner = createMember('k6-rest-read-owner');
+    const posts = [];
+
+    for (let index = 0; index < SEED_POSTS; index += 1) {
+        const post = createPost(owner.memberId, {
+            title: `k6 seed post ${index}`,
+            content: 'Seed data for REST read performance tests.',
+            price: 1000 + index,
+        });
+        posts.push(post.postId);
+    }
+
+    return {
+        authorization: owner.token.authorization,
+        posts,
+    };
+}
+
+export default function (data) {
+    const postId = data.posts[Math.floor(Math.random() * data.posts.length)];
+
+    const me = http.get(`${BASE_URL}/api/v1/members`, {
+        headers: {
+            Authorization: data.authorization,
+        },
+        tags: {
+            endpoint: 'member_info',
+        },
+    });
+    check(me, {
+        'member info status is 200': (r) => r.status === 200,
+    });
+
+    const list = http.get(`${BASE_URL}/api/v1/posts?page=0&size=20`, {
+        tags: {
+            endpoint: 'post_list',
+        },
+    });
+    check(list, {
+        'post list status is 200': (r) => r.status === 200,
+    });
+
+    const detail = http.get(`${BASE_URL}/api/v1/posts/${postId}`, {
+        tags: {
+            endpoint: 'post_detail',
+        },
+    });
+    check(detail, {
+        'post detail status is 200': (r) => r.status === 200,
+    });
+
+    sleep(1);
+}


### PR DESCRIPTION
서버의 REST API, WebSocket/STOMP 채팅, 알림 SSE 흐름에 대해 k6 기반 성능 테스트를 도입

### 공통 유틸

- `k6/lib/api.js`
- 회원가입, 로그인, 인증 헤더 생성, 게시글 생성, 채팅방 입장, JSON 응답 안전 파싱 함수 추가

### REST 성능 테스트

- `k6/scripts/auth-flow.js` 인증 플로우 테스트
- `k6/scripts/rest-read.js` REST API의 read 기능 종합 테스트
- `k6/scripts/posts.js` 게시글 테스트
- `k6/scripts/chat-http.js` 채팅 CRUD 테스트

### WebSocket/STOMP 테스트

- `k6/scripts/chat-ws.js`
- WebSocket handshake 확인
- STOMP CONNECT 확인
- SUBSCRIBE 확인
- SEND 후 실제 MESSAGE 수신 확인
- ERROR 프레임 미수신 확인

### 알림 SSE 테스트

- `k6/scripts/notification-sse.js`
- `k6/x/sse` 확장 사용
- SSE 구독 응답 `200` 확인
- `Content-Type: text/event-stream` 확인
- `notification` 이벤트 수신 확인
- 연결 성공 메시지에 `receiverId` 포함 여부 확인
- 알림 목록 조회 API 확인

## Issue
k6 이외의 부분에서 테스트 지원을 위한 개발이 필요함

### SSE
- 내부 이벤트가 아닌 외부 호출 함수가 필요
- `k6/x/sse` 사용으로 인해 네트워크가 막힌 환경에서는 자동 프로비저닝이 실패할 수 있음

### WS / STOMP
-  WebSocket/STOMP 정확성, 장기 연결, 메시지 전달 지연 확인을 위한 커스텀 클라이언트 필요

resolved #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * k6 기반 성능 테스트 스위트 추가: 인증, 게시글 CRUD, 채팅(HTTP/WS), 알림(SSE), 읽기 전용 시나리오 및 VU/기간 설정 포함
  * 공통 테스트 유틸리티 추가: 회원 생성/가입/로그인, 인증 헤더, 게시글·채팅 입장 등 재사용 가능한 헬퍼 제공
  * 테스트용 시드 사용자 데이터 추가

* **Documentation**
  * README 재정비: 실행 가이드, 명령 예시, 구성값(TARGET_VUS/TEST_DURATION) 변경 방법, 임계값(Checks/HTTP/WS/SSE) 설명, 데이터 누적 및 SSE 확장 필요성 안내

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Gmo-Daangn/server/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->