### PR TITLE
docs/chat api spring docs 적용

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -42,3 +42,98 @@ include::{snippets}/member-info-success/response-fields.adoc[]
 
 === CURL
 include::{snippets}/member-info-success/curl-request.adoc[]
+
+== 채팅방 생성 성공
+
+=== 요청
+include::{snippets}/chat-room-enter-success/http-request.adoc[]
+include::{snippets}/chat-room-enter-success/request-fields.adoc[]
+
+=== 응답
+include::{snippets}/chat-room-enter-success/http-response.adoc[]
+include::{snippets}/chat-room-enter-success/response-fields.adoc[]
+
+=== CURL
+include::{snippets}/chat-room-enter-success/curl-request.adoc[]
+
+== 채팅방 재입장 성공
+
+=== 요청
+include::{snippets}/chat-room-reenter-success/http-request.adoc[]
+include::{snippets}/chat-room-reenter-success/request-fields.adoc[]
+
+=== 응답
+include::{snippets}/chat-room-reenter-success/http-response.adoc[]
+include::{snippets}/chat-room-reenter-success/response-fields.adoc[]
+
+=== CURL
+include::{snippets}/chat-room-reenter-success/curl-request.adoc[]
+
+== 채팅방 목록 조회 성공
+
+=== 요청
+include::{snippets}/chat-room-list-success/http-request.adoc[]
+include::{snippets}/chat-room-list-success/query-parameters.adoc[]
+
+=== 응답
+include::{snippets}/chat-room-list-success/http-response.adoc[]
+include::{snippets}/chat-room-list-success/response-fields.adoc[]
+
+=== CURL
+include::{snippets}/chat-room-list-success/curl-request.adoc[]
+
+== 채팅 메시지 목록 조회 성공
+
+=== 요청
+include::{snippets}/chat-message-list-success/http-request.adoc[]
+include::{snippets}/chat-message-list-success/path-parameters.adoc[]
+include::{snippets}/chat-message-list-success/query-parameters.adoc[]
+
+=== 응답
+include::{snippets}/chat-message-list-success/http-response.adoc[]
+include::{snippets}/chat-message-list-success/response-fields.adoc[]
+
+=== CURL
+include::{snippets}/chat-message-list-success/curl-request.adoc[]
+
+== 채팅방 읽음 처리 성공
+
+=== 요청
+include::{snippets}/chat-room-read-success/http-request.adoc[]
+include::{snippets}/chat-room-read-success/path-parameters.adoc[]
+include::{snippets}/chat-room-read-success/request-fields.adoc[]
+
+=== 응답
+include::{snippets}/chat-room-read-success/http-response.adoc[]
+include::{snippets}/chat-room-read-success/response-fields.adoc[]
+
+=== CURL
+include::{snippets}/chat-room-read-success/curl-request.adoc[]
+
+== 채팅 메시지 수정 성공
+
+=== 요청
+include::{snippets}/chat-message-edit-success/http-request.adoc[]
+include::{snippets}/chat-message-edit-success/path-parameters.adoc[]
+include::{snippets}/chat-message-edit-success/request-fields.adoc[]
+
+=== 응답
+include::{snippets}/chat-message-edit-success/http-response.adoc[]
+include::{snippets}/chat-message-edit-success/response-fields.adoc[]
+
+=== CURL
+include::{snippets}/chat-message-edit-success/curl-request.adoc[]
+
+== 채팅 메시지 삭제 성공
+
+=== 요청
+include::{snippets}/chat-message-delete-success/http-request.adoc[]
+include::{snippets}/chat-message-delete-success/path-parameters.adoc[]
+include::{snippets}/chat-message-delete-success/request-fields.adoc[]
+
+=== 응답
+include::{snippets}/chat-message-delete-success/http-response.adoc[]
+include::{snippets}/chat-message-delete-success/response-fields.adoc[]
+
+=== CURL
+include::{snippets}/chat-message-delete-success/curl-request.adoc[]

--- a/src/test/java/com/ktcloud/daangn/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/chat/integration/ChatIntegrationTest.java
@@ -8,8 +8,10 @@ import com.ktcloud.daangn.member.entity.Member;
 import com.ktcloud.daangn.member.entity.MemberRole;
 import com.ktcloud.daangn.member.entity.ProviderToken;
 import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -24,10 +26,14 @@ import org.springframework.messaging.simp.stomp.StompFrameHandler;
 import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 
@@ -41,6 +47,15 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -49,9 +64,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Import(TestContainerConfig.class)
 @ActiveProfiles("test")
+@ExtendWith(RestDocumentationExtension.class)
 class ChatIntegrationTest {
 
-    @Autowired
     private MockMvc mockMvc;
 
     @Autowired
@@ -62,6 +77,14 @@ class ChatIntegrationTest {
 
     @LocalServerPort
     private int port;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentation))
+                .apply(springSecurity())
+                .build();
+    }
 
     private static Long readLong(String json, String expression) {
         Number number = JsonPath.read(json, expression);
@@ -93,6 +116,21 @@ class ChatIntegrationTest {
         MvcResult enterResult = enterRoom(members, 100L)
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.created").value(true))
+                .andDo(document("chat-room-enter-success",
+                        requestFields(
+                                fieldWithPath("memberId").description("채팅방에 입장하는 회원 ID"),
+                                fieldWithPath("targetMemberId").description("1대1 채팅 상대 회원 ID"),
+                                fieldWithPath("productId").description("상품 기반 채팅일 경우 상품 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("HTTP 상태 코드"),
+                                fieldWithPath("localDateTime").description("응답 시간"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.roomId").description("채팅방 ID"),
+                                fieldWithPath("data.created").description("새 채팅방 생성 여부"),
+                                fieldWithPath("data.message").description("채팅방 입장 결과 메시지")
+                        )
+                ))
                 .andReturn();
         Long roomId = readLong(enterResult, "$.data.roomId");
 
@@ -130,12 +168,70 @@ class ChatIntegrationTest {
                             .param("memberId", members.senderId().toString()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data[0].messageId").value(sentMessage.messageId()))
-                    .andExpect(jsonPath("$.data[0].message").value("hello integration"));
+                    .andExpect(jsonPath("$.data[0].message").value("hello integration"))
+                    .andDo(document("chat-message-list-success",
+                            pathParameters(
+                                    parameterWithName("roomId").description("메시지를 조회할 채팅방 ID")
+                            ),
+                            queryParameters(
+                                    parameterWithName("memberId").description("메시지 목록을 조회하는 회원 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("HTTP 상태 코드"),
+                                    fieldWithPath("localDateTime").description("응답 시간"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data[].messageId").description("메시지 ID"),
+                                    fieldWithPath("data[].roomId").description("채팅방 ID"),
+                                    fieldWithPath("data[].senderId").description("메시지 작성자 회원 ID"),
+                                    fieldWithPath("data[].message").description("메시지 내용"),
+                                    fieldWithPath("data[].edited").description("메시지 수정 여부"),
+                                    fieldWithPath("data[].deleted").description("메시지 삭제 여부"),
+                                    fieldWithPath("data[].unreadCount").description("메시지를 아직 읽지 않은 참여자 수"),
+                                    fieldWithPath("data[].createdAt").description("메시지 생성 시간")
+                            )
+                    ));
+
+            mockMvc.perform(get("/api/v1/chat/rooms")
+                            .param("memberId", members.senderId().toString()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].roomId").value(roomId))
+                    .andDo(document("chat-room-list-success",
+                            queryParameters(
+                                    parameterWithName("memberId").description("채팅방 목록을 조회하는 회원 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("HTTP 상태 코드"),
+                                    fieldWithPath("localDateTime").description("응답 시간"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data[].roomId").description("채팅방 ID"),
+                                    fieldWithPath("data[].productId").description("채팅방과 연결된 상품 ID"),
+                                    fieldWithPath("data[].otherMemberId").description("상대 회원 ID"),
+                                    fieldWithPath("data[].otherMemberNickname").description("상대 회원 닉네임"),
+                                    fieldWithPath("data[].lastMessage").description("마지막 메시지 내용"),
+                                    fieldWithPath("data[].lastMessageCreatedAt").description("마지막 메시지 생성 시간"),
+                                    fieldWithPath("data[].unreadMessageCount").description("채팅방의 미읽음 메시지 수")
+                            )
+                    ));
 
             enterRoom(members, 100L)
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.roomId").value(roomId))
-                    .andExpect(jsonPath("$.data.created").value(false));
+                    .andExpect(jsonPath("$.data.created").value(false))
+                    .andDo(document("chat-room-reenter-success",
+                            requestFields(
+                                    fieldWithPath("memberId").description("채팅방에 입장하는 회원 ID"),
+                                    fieldWithPath("targetMemberId").description("1대1 채팅 상대 회원 ID"),
+                                    fieldWithPath("productId").description("상품 기반 채팅일 경우 상품 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("HTTP 상태 코드"),
+                                    fieldWithPath("localDateTime").description("응답 시간"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data.roomId").description("기존 채팅방 ID"),
+                                    fieldWithPath("data.created").description("새 채팅방 생성 여부"),
+                                    fieldWithPath("data.message").description("채팅방 입장 결과 메시지")
+                            )
+                    ));
 
             mockMvc.perform(post("/api/v1/chat/rooms/read/{roomId}", roomId)
                             .contentType(MediaType.APPLICATION_JSON)
@@ -145,7 +241,23 @@ class ChatIntegrationTest {
                                     }
                                     """.formatted(members.receiverId())))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.readMessageCount").value(1));
+                    .andExpect(jsonPath("$.data.readMessageCount").value(1))
+                    .andDo(document("chat-room-read-success",
+                            pathParameters(
+                                    parameterWithName("roomId").description("읽음 처리할 채팅방 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("memberId").description("읽음 처리 요청 회원 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("HTTP 상태 코드"),
+                                    fieldWithPath("localDateTime").description("응답 시간"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data.roomId").description("읽음 처리된 채팅방 ID"),
+                                    fieldWithPath("data.memberId").description("읽음 처리 요청 회원 ID"),
+                                    fieldWithPath("data.readMessageCount").description("읽음 처리된 메시지 수")
+                            )
+                    ));
 
             mockMvc.perform(get("/api/v1/chat/messages/{roomId}", roomId)
                             .param("memberId", members.receiverId().toString()))
@@ -162,7 +274,29 @@ class ChatIntegrationTest {
                                     """.formatted(members.senderId())))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.message").value("edited integration"))
-                    .andExpect(jsonPath("$.data.edited").value(true));
+                    .andExpect(jsonPath("$.data.edited").value(true))
+                    .andDo(document("chat-message-edit-success",
+                            pathParameters(
+                                    parameterWithName("messageId").description("수정할 메시지 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("memberId").description("메시지 수정 요청 회원 ID"),
+                                    fieldWithPath("message").description("수정할 메시지 내용")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("HTTP 상태 코드"),
+                                    fieldWithPath("localDateTime").description("응답 시간"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data.messageId").description("메시지 ID"),
+                                    fieldWithPath("data.roomId").description("채팅방 ID"),
+                                    fieldWithPath("data.senderId").description("메시지 작성자 회원 ID"),
+                                    fieldWithPath("data.message").description("수정된 메시지 내용"),
+                                    fieldWithPath("data.edited").description("메시지 수정 여부"),
+                                    fieldWithPath("data.deleted").description("메시지 삭제 여부"),
+                                    fieldWithPath("data.unreadCount").description("메시지를 아직 읽지 않은 참여자 수"),
+                                    fieldWithPath("data.createdAt").description("메시지 생성 시간")
+                            )
+                    ));
 
             ChatMessageResponseDto editedMessage = pollMessage(messageEvents);
             assertThat(editedMessage.messageId()).isEqualTo(sentMessage.messageId());
@@ -178,7 +312,28 @@ class ChatIntegrationTest {
                                     """.formatted(members.senderId())))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.deleted").value(true))
-                    .andExpect(jsonPath("$.data.message").value("삭제된 메시지입니다."));
+                    .andExpect(jsonPath("$.data.message").value("삭제된 메시지입니다."))
+                    .andDo(document("chat-message-delete-success",
+                            pathParameters(
+                                    parameterWithName("messageId").description("삭제할 메시지 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("memberId").description("메시지 삭제 요청 회원 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("HTTP 상태 코드"),
+                                    fieldWithPath("localDateTime").description("응답 시간"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data.messageId").description("메시지 ID"),
+                                    fieldWithPath("data.roomId").description("채팅방 ID"),
+                                    fieldWithPath("data.senderId").description("메시지 작성자 회원 ID"),
+                                    fieldWithPath("data.message").description("삭제 처리 후 메시지 내용"),
+                                    fieldWithPath("data.edited").description("메시지 수정 여부"),
+                                    fieldWithPath("data.deleted").description("메시지 삭제 여부"),
+                                    fieldWithPath("data.unreadCount").description("메시지를 아직 읽지 않은 참여자 수"),
+                                    fieldWithPath("data.createdAt").description("메시지 생성 시간")
+                            )
+                    ));
 
             ChatMessageResponseDto deletedMessage = pollMessage(messageEvents);
             assertThat(deletedMessage.messageId()).isEqualTo(sentMessage.messageId());


### PR DESCRIPTION
### chat api docs 생성을 위한 spring docs 적용

## 적용 범위
- ChatIntegrationTest
- 채팅방 : 생성, 입장, 조회
- 메시지 : 조회, 읽음, 수정, 삭제
<img width="2540" height="1286" alt="SCR-20260519-ljdl" src="https://github.com/user-attachments/assets/ac929199-99c6-461a-ab48-761657370232" />

resolved #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 채팅 관련 "성공" API 문서 대폭 추가: 채팅방 생성/재입장/입장, 채팅방 목록 조회, 메시지 목록 조회, 메시지 수정·삭제, 읽음 처리 등
  * 각 섹션에 요청(경로/쿼리/헤더/본문) 및 응답 필드 명세 추가
  * CURL 예제 스니펫 포함으로 사용성 향상
  * 통합 테스트의 문서화 적용으로 API 스펙 검증 자동화 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Gmo-Daangn/server/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->