### PR TITLE
Chore/jacoco 툴 적용 및 testContainer 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testCompileOnly 'org.projectlombok:lombok'
+    testImplementation 'org.junit.platform:junit-platform-suite'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,53 +1,66 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '4.0.5'
-	id 'io.spring.dependency-management' version '1.1.7'
-	id 'org.asciidoctor.jvm.convert' version '4.0.5'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.5'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.asciidoctor.jvm.convert' version '4.0.5'
+    id 'jacoco'
 }
 
 group = 'com.ktcloud'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(25)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 configurations {
-	mockitoAgent
-	asciidoctorExtensions
+    mockitoAgent
+    asciidoctorExtensions
 }
 
 asciidoctorj {
-	version = "3.0.0"
+    version = "3.0.0"
 }
 
 ext {
-	snippetsDir = file('build/generated-snippets')
+    snippetsDir = file('build/generated-snippets')
+}
+
+def jacocoIncludedPackages = [
+        '**/service/**',
+        '**/entity/**',
+        '**/repository/**'
+]
+
+def jacocoTargetClassDirectories = {
+    files(sourceSets.main.output.classesDirs.collect {
+        fileTree(dir: it, includes: jacocoIncludedPackages)
+    })
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-	implementation 'org.springframework.boot:spring-boot-starter-aspectj'
-	implementation 'org.springframework.security:spring-security-core'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-	testCompileOnly 'org.projectlombok:lombok'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testAnnotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-aspectj'
+    implementation 'org.springframework.security:spring-security-core'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testCompileOnly 'org.projectlombok:lombok'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     // JWT 라이브러리
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
@@ -60,41 +73,70 @@ dependencies {
     // AWS S3
     // implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
-	//test 환경 dependency
-	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-	testImplementation platform('org.testcontainers:testcontainers-bom:2.0.4')
-	testImplementation 'org.testcontainers:testcontainers-mysql'
-	testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
+    //test 환경 dependency
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation platform('org.testcontainers:testcontainers-bom:2.0.4')
+    testImplementation 'org.testcontainers:testcontainers-mysql'
+    testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
 
-	mockitoAgent('org.mockito:mockito-core') {
-		transitive = false
-	}
+    mockitoAgent('org.mockito:mockito-core') {
+        transitive = false
+    }
 
-	//Spring REST Docs
-	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor:4.0.0'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:4.0.0'
+    //Spring REST Docs
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor:4.0.0'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:4.0.0'
 
-	//UUID Creator
-	implementation 'com.github.f4b6a3:uuid-creator:6.1.1'
+    //UUID Creator
+    implementation 'com.github.f4b6a3:uuid-creator:6.1.1'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
-	jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
-	outputs.dir snippetsDir
+    useJUnitPlatform()
+    jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
+    outputs.dir snippetsDir
+    finalizedBy tasks.jacocoTestReport // report is always generated after tests run
 }
 
 tasks.named("asciidoctor") {
-	configurations = ["asciidoctorExtensions"]
-	inputs.dir snippetsDir
-	dependsOn test
+    configurations = ["asciidoctorExtensions"]
+    inputs.dir snippetsDir
+    dependsOn test
 }
 
 tasks.named("bootJar") {
-	dependsOn tasks.named("asciidoctor")
+    dependsOn tasks.named("asciidoctor")
 
-	copy {
-		from asciidoctor.outputDir
-		into "src/main/resources/static/docs"
-	}
+    copy {
+        from asciidoctor.outputDir
+        into "src/main/resources/static/docs"
+    }
+}
+
+jacocoTestReport {
+    dependsOn tasks.test
+    reports {
+        xml.required = false
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+        csv.required = false
+    }
+    classDirectories.setFrom(jacocoTargetClassDirectories())
+    finalizedBy(jacocoTestCoverageVerification)
+}
+
+jacocoTestCoverageVerification {
+    classDirectories.setFrom(jacocoTargetClassDirectories())
+
+    violationRules {
+        rule {
+            enabled = true
+            element = "CLASS"
+
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = 0
+            }
+        }
+    }
 }

--- a/src/test/java/com/ktcloud/daangn/auth/controller/AuthLoginDocTest.java
+++ b/src/test/java/com/ktcloud/daangn/auth/controller/AuthLoginDocTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -29,7 +28,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,9 +35,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Import(TestContainerConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
-public class AuthLoginDocTest {
+public class AuthLoginDocTest extends TestContainerConfig {
     /**
      * 로그인 로직의 경우 스프링 시큐리티관리로 필터에서 로그인이 진행되므로
      * SpringBootTest로 작성
@@ -67,12 +64,12 @@ public class AuthLoginDocTest {
     @DisplayName("로그인")
     class Login {
 
-        private  final Address address = new Address("서울시","동작구","사당동");
+        private final Address address = new Address("서울시", "동작구", "사당동");
 
         @Test
         @Transactional
         @DisplayName("[HAPPY] 로그인시 정상적으로 작동한다.")
-        public void login_ValidRequest_Success() throws Exception{
+        public void login_ValidRequest_Success() throws Exception {
             //given
             AuthSignupRequestDto dto = new AuthSignupRequestDto("test@test.com", "이름", "password", address);
             em.persist(dto.toMember(passwordEncoder.encode(dto.password())));
@@ -87,7 +84,7 @@ public class AuthLoginDocTest {
                     .andDo(document("auth-login-success", requestFields(
                             fieldWithPath("email").description("이메일"),
                             fieldWithPath("password").description("비밀번호")
-                    ),responseFields(
+                    ), responseFields(
                             fieldWithPath("code").description("HTTP Status Code"),
                             fieldWithPath("localDateTime").description("시간"),
                             fieldWithPath("message").description("설명 메시지"),

--- a/src/test/java/com/ktcloud/daangn/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/auth/service/AuthServiceIntegrationTest.java
@@ -1,15 +1,14 @@
 package com.ktcloud.daangn.auth.service;
 
-import com.ktcloud.daangn.config.TestContainerConfig;
+import com.ktcloud.daangn.auth.dto.AuthSignupRequestDto;
 import com.ktcloud.daangn.common.exception.InvalidInputException;
 import com.ktcloud.daangn.common.valueObject.Address;
-import com.ktcloud.daangn.auth.dto.AuthSignupRequestDto;
+import com.ktcloud.daangn.config.TestContainerConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,15 +17,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 @SpringBootTest
-@Import(TestContainerConfig.class)
 @ActiveProfiles("test")
 @Transactional
-class AuthServiceIntegrationTest {
+class AuthServiceIntegrationTest extends TestContainerConfig {
 
+    private final Address address = new Address("서울시", "동작구", "사당동");
     @Autowired
     private AuthService authService;
-
-    private  final Address address = new Address("서울시","동작구","사당동");
 
     @Nested
     @DisplayName("회원가입")
@@ -46,7 +43,7 @@ class AuthServiceIntegrationTest {
 
         @Test
         @DisplayName("[Exception] 중복된 이메일로 회원가입하면 예외처리가 정상작동한다.")
-        public void signup_DuplicateEmail_ExceptionThrown(){
+        public void signup_DuplicateEmail_ExceptionThrown() {
             //given
             AuthSignupRequestDto dto = new AuthSignupRequestDto("test@test.com", "이름", "password", address);
             //when

--- a/src/test/java/com/ktcloud/daangn/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/chat/integration/ChatIntegrationTest.java
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.converter.ByteArrayMessageConverter;
 import org.springframework.messaging.converter.CompositeMessageConverter;
@@ -49,12 +48,8 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -62,10 +57,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@Import(TestContainerConfig.class)
 @ActiveProfiles("test")
 @ExtendWith(RestDocumentationExtension.class)
-class ChatIntegrationTest {
+class ChatIntegrationTest extends TestContainerConfig {
 
     private MockMvc mockMvc;
 
@@ -77,14 +71,6 @@ class ChatIntegrationTest {
 
     @LocalServerPort
     private int port;
-
-    @BeforeEach
-    void setUp(WebApplicationContext context, RestDocumentationContextProvider restDocumentation) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-                .apply(documentationConfiguration(restDocumentation))
-                .apply(springSecurity())
-                .build();
-    }
 
     private static Long readLong(String json, String expression) {
         Number number = JsonPath.read(json, expression);
@@ -105,6 +91,14 @@ class ChatIntegrationTest {
                 readLong(json, "$.unreadCount"),
                 LocalDateTime.parse(JsonPath.read(json, "$.createdAt"))
         );
+    }
+
+    @BeforeEach
+    void setUp(WebApplicationContext context, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentation))
+                .apply(springSecurity())
+                .build();
     }
 
     @Test

--- a/src/test/java/com/ktcloud/daangn/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/chat/integration/ChatIntegrationTest.java
@@ -55,7 +55,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @ExtendWith(RestDocumentationExtension.class)

--- a/src/test/java/com/ktcloud/daangn/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/chat/integration/ChatIntegrationTest.java
@@ -55,7 +55,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @ExtendWith(RestDocumentationExtension.class)

--- a/src/test/java/com/ktcloud/daangn/chat/service/ChatMessageServiceImplTest.java
+++ b/src/test/java/com/ktcloud/daangn/chat/service/ChatMessageServiceImplTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,10 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
-@Import(TestContainerConfig.class)
 @ActiveProfiles("test")
 @Transactional
-class ChatMessageServiceImplTest {
+class ChatMessageServiceImplTest extends TestContainerConfig {
 
     @Autowired
     private ChatMessageService chatMessageService;

--- a/src/test/java/com/ktcloud/daangn/chat/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/ktcloud/daangn/chat/service/ChatRoomServiceImplTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,10 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
-@Import(TestContainerConfig.class)
 @ActiveProfiles("test")
 @Transactional
-class ChatRoomServiceImplTest {
+class ChatRoomServiceImplTest extends TestContainerConfig {
 
     @Autowired
     private ChatRoomService chatRoomService;

--- a/src/test/java/com/ktcloud/daangn/config/TestContainerConfig.java
+++ b/src/test/java/com/ktcloud/daangn/config/TestContainerConfig.java
@@ -1,16 +1,22 @@
 package com.ktcloud.daangn.config;
 
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.mysql.MySQLContainer;
 
-@TestConfiguration(proxyBeanMethods = false)
-public class TestContainerConfig {
+public abstract class TestContainerConfig {
 
-    @Bean
-    @ServiceConnection
-    public MySQLContainer mySQLContainer(){
-        return new MySQLContainer("mysql:9.7");
+    private static final MySQLContainer MYSQL = new MySQLContainer("mysql:9.7");
+
+    static {
+        MYSQL.start();
+    }
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
     }
 }

--- a/src/test/java/com/ktcloud/daangn/member/service/MemberServiceIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/member/service/MemberServiceIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.ktcloud.daangn.member.service;
 
-import com.ktcloud.daangn.config.TestContainerConfig;
 import com.ktcloud.daangn.common.valueObject.Address;
+import com.ktcloud.daangn.config.TestContainerConfig;
 import com.ktcloud.daangn.member.dto.MemberInfoResponseDto;
 import com.ktcloud.daangn.member.entity.Member;
 import jakarta.persistence.EntityManager;
@@ -9,29 +9,25 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-@Import(TestContainerConfig.class)
 @ActiveProfiles("test")
 @Transactional
-public class MemberServiceIntegrationTest {
+public class MemberServiceIntegrationTest extends TestContainerConfig {
 
+    private final Address address = new Address("서울시", "동작구", "사당동");
     @Autowired
     private MemberService memberService;
-
     @Autowired
     private EntityManager em;
 
-    private final Address address = new Address("서울시", "동작구", "사당동");
-
     @Test
     @DisplayName("[HAPPY] 내 정보 조회시 성공적으로 반환한다.")
-    public void getMyInfo_ValidMember_Success(){
+    public void getMyInfo_ValidMember_Success() {
         //given
         Member member = Member.builder()
                 .email("test@test.com")

--- a/src/test/java/com/ktcloud/daangn/notification/service/NotificationServiceIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/notification/service/NotificationServiceIntegrationTest.java
@@ -1,8 +1,8 @@
 package com.ktcloud.daangn.notification.service;
 
-import com.ktcloud.daangn.config.TestContainerConfig;
 import com.ktcloud.daangn.common.exception.InvalidInputException;
 import com.ktcloud.daangn.common.valueObject.Address;
+import com.ktcloud.daangn.config.TestContainerConfig;
 import com.ktcloud.daangn.member.entity.Member;
 import com.ktcloud.daangn.member.entity.MemberRole;
 import com.ktcloud.daangn.member.entity.ProviderToken;
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,10 +25,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
-@Import(TestContainerConfig.class)
 @ActiveProfiles("test")
 @Transactional
-class NotificationServiceIntegrationTest {
+class NotificationServiceIntegrationTest extends TestContainerConfig {
 
     @Autowired
     private NotificationService notificationService;


### PR DESCRIPTION
## Jacoco 툴 적용
- jacoco 툴 적용
- 저장 경로
<img width="340" height="581" alt="SCR-20260601-nuuh" src="https://github.com/user-attachments/assets/d1cdb239-46b3-49fb-8568-b4bb70f3ee06" />

### 보고 범위
- service
- entity
- repository
<img width="1089" height="455" alt="SCR-20260601-nwbv" src="https://github.com/user-attachments/assets/d9b0d91c-4e2c-4452-85b7-2eab3dd71626" />

## 테스트 컨테이너
### Singleton static 컨테이너
- `@TestContainer` 사용 방식에서 static singleton 방식으로 변경
- yml 파일의 해당 부분만 수정하는 간단한 방법이 있지만 추후 db 컨테이너의 설정을 더 자세하게 바꿔가면서 테스트 할 경우를 대비하여 싱글톤 방식을 채택 
<img width="484" height="384" alt="SCR-20260601-nxtq" src="https://github.com/user-attachments/assets/394dd422-5856-4da7-be34-8747766a9a1a" />

- 추후 테스트코드 작성 시 `testcontainerconfig`를 `extends` 해서 작성 필요
- `@Import(TestContainerConfig.class)` 어노테이션은 붙여선 안됨
<img width="660" height="123" alt="SCR-20260601-nzoq" src="https://github.com/user-attachments/assets/8f2601dc-8b5f-4887-8d2d-8319b3838aeb" />

## 테스트 결과
### Before
<img width="1258" height="980" alt="before" src="https://github.com/user-attachments/assets/143cf302-3843-4a04-ac40-f0d319e605ca" />

### After
<img width="1250" height="984" alt="after" src="https://github.com/user-attachments/assets/8397a7d8-4a0f-4c85-ae03-7860947ece21" />

### 정리
테스트 컨테이너를 기존의 JUnit 이 관리하는 `@TestContainer` 가 아닌 직접 TestContainer Cors를 호출하는 방식인 싱글톤 방식으로 변경하여 전체 테스트에서 한번만 db 컨테이너를 생성하도록 변경됨
기존 컨테이너를 계속 다시 생성하던 테스트들의 속도가 1000ms 이상에서 100ms 단위까지 변경됨
컨테이너는 jvm 종료 과정에서 삭제되지만 kill 등 명령어를 통해 shutdown 절차를 진행하지 못하면 남아있을 수 있음

resolved #65 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 테스트 커버리지 자동 측정 및 검증 기능 강화
  * 테스트 환경 설정 방식 통합으로 유지보수성 개선

* **Chores**
  * 테스트 관련 의존성 추가 (Testcontainers, Mockito, Spring REST Docs)
  * 빌드 파이프라인 확장으로 테스트 및 문서화 자동화 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->