### PR TITLE
test: SSE .send() 테스트 및 예외처리 테스트 추가

### DIFF
--- a/src/test/java/com/ktcloud/daangn/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/ktcloud/daangn/notification/service/NotificationServiceImplTest.java
@@ -23,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +33,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -136,6 +139,38 @@ class NotificationServiceImplTest {
             assertThat(captured.getTemplate()).isEqualTo(template);
             assertThat(captured.getMessage()).isEqualTo("안녕 주문완료");
             verify(emitterRepository).get(MEMBER_ID);
+        }
+
+        @Test
+        @DisplayName("[HAPPY] 활성화된 SSE 연결이 존재하면 클라이언트로 이벤트를 정상 전송한다")
+        void create_validEvent_sendsSseSuccessfully() throws IOException {
+            givenExistingMember(MEMBER_ID);
+            stubTemplateRepository("ORDER", "안녕 {templateText}");
+
+            SseEmitter mockEmitter = mock(SseEmitter.class);
+            given(emitterRepository.get(MEMBER_ID)).willReturn(mockEmitter);
+
+            NotificationEvent event = new NotificationEvent(MEMBER_ID, "ORDER", 99L, "주문완료");
+            notificationService.createAndSendNotification(event);
+
+            verify(mockEmitter).send(any(SseEmitter.SseEventBuilder.class));
+        }
+
+        @Test
+        @DisplayName("[Exception] SSE 전송 중 IOException 발생 시 emitter를 저장소에서 삭제한다")
+        void create_validEvent_deletesEmitterOnIoException() throws IOException {
+            givenExistingMember(MEMBER_ID);
+            stubTemplateRepository("ORDER", "안녕 {templateText}");
+
+            SseEmitter mockEmitter = mock(SseEmitter.class);
+            given(emitterRepository.get(MEMBER_ID)).willReturn(mockEmitter);
+
+            doThrow(new IOException("클라이언트 연결 끊김")).when(mockEmitter).send(any(SseEmitter.SseEventBuilder.class));
+
+            NotificationEvent event = new NotificationEvent(MEMBER_ID, "ORDER", 99L, "주문완료");
+            notificationService.createAndSendNotification(event);
+
+            verify(emitterRepository).deleteById(MEMBER_ID);
         }
 
         @Test


### PR DESCRIPTION
### 작업 내용
- `emitterRepository.get()`이 정상적으로 `SseEmitter`를 반환할 때, `.send()`가 성공적으로 호출되는지 검증하는 테스트 추가
- `emitter.send()` 실행 시 `IOException`이 발생하도록 Mocking하여 예외 처리(삭제 로직)를 확인하는 테스트 추가

Jacoco Missing Branch 50% -> 100%

resoloved #67 