### PR TITLE
chore/모니터링 툴 적용 1차 완료 prometheus, grafana 연동 및 매트릭스 연결 확인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,10 @@ dependencies {
 
     //UUID Creator
     implementation 'com.github.f4b6a3:uuid-creator:6.1.1'
+
+    //Prometheus, Actuator
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,65 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     ports:
       - "3306:3306"
-
-
     volumes:
       - ./mysql_data:/var/lib/mysql
+
+  influxdb:
+    image: influxdb:1.8
+    container_name: local-influxdb
+    ports:
+      - "8086:8086"
+    volumes:
+      - influxdb-data:/var/lib/influxdb
+    environment:
+      - INFLUXDB_DB=k6
+      - INFLUXDB_ADMIN_ENABLED=true
+      - INFLUXDB_ADMIN_USER=admin
+      - INFLUXDB_ADMIN_PASSWORD=admin
+      - INFLUXDB_HTTP_MAX_BODY_SIZE=0
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: local-prometheus
+    ports:
+      - "9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+
+  grafana:
+    image: grafana/grafana
+    container_name: local-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_INSTALL_PLUGINS=grafana-clock-panel
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - influxdb
+      - prometheus
+
+
+  mysql-exporter:
+    image: prom/mysqld-exporter:latest
+    container_name: mysql-exporter
+    restart: always
+    ports:
+      - 9104:9104
+    command:
+      - "--mysqld.username=${MYSQL_USER}:${MYSQL_PASSWORD}"
+      - "--mysqld.address=db:3306"
+    depends_on:
+      - db
+
+volumes:
+  influxdb-data:
+  grafana-data:
+  prometheus-data:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,24 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: [ 'prometheus:9090' ]
+
+  # Spring Boot 앱 (HikariCP 메트릭 포함)
+  - job_name: 'daangn-server'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:8080' ]
+        labels:
+          application: 'gmo-daangn'
+
+  # DB 모니터링
+  - job_name: 'mysql-exporter'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: [ 'mysql-exporter:9104' ]
+        labels:
+          application: 'gmo-daangn'

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,7 +12,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-        ddl-auto: create
+      ddl-auto: create
     show-sql: true
     open-in-view: false
     properties:
@@ -50,3 +50,32 @@ logging:
 jwt:
   access_secret: ${ACCESS_JWT_KEY}
 #  refresh_secret: ${REFRESH_JWT_KEY}
+
+# 모니터링 설정
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"  # 모든 엔드포인트 노출 (개발용)
+      base-path: /actuator
+
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true
+
+  metrics:
+    enable:
+      jvm: true
+      system: true
+      tomcat: true
+      process: true
+      hikaricp: true
+      jdbc: true
+    tags:
+      application: ${spring.application.name}
+  prometheus:
+    metrics:
+      export:
+        enabled: true


### PR DESCRIPTION
## 모니터링 툴
성능 테스트 모니터링을 위해 prometheus와 grafana를 1차적으로 적용했습니다.
현재 서버의 actuator를 통해 생성된 matrics와 mysql-exporter로 읽어온 db정보를 프로메테우스가 수집하고 그라파나의 대쉬보드를 통해 확인할 수 있도록 했습니다.
현재 dev서버만 모니터링 할 수 있도록 application-dev만 수정한 상태입니다.

### Prometheus
<img width="2547" height="989" alt="SCR-20260612-iohd" src="https://github.com/user-attachments/assets/824399fe-697b-44ba-acef-e027b789016e" />

- DB, Server 정보 수집을 위한 연결 확인
- 설정에 대한 변경은 prometheus.yml 및 docker-compose.yml에서 가능

### Grafana
<img width="2525" height="1249" alt="SCR-20260612-ipzs" src="https://github.com/user-attachments/assets/64bd4582-46cb-45b2-b00a-2ea38f7c89ed" />

- 기본적인 mysql 대시보드 설정은 아래 블로그 참고
- DS_PROMETHEUS 관련 오류가 나타날 시 수업 때 처럼 데이터소스를 직접 리소스로 넣어서 해결하거나 json의 datasource: uid를 직접 수정해서 해결 가능
- [그라파나 대시보드 설정](https://velog.io/@shin_0224/MySQL-%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81Prometheus-Grafana)

resolved #76 