### PR TITLE
Test : payment concurrency 검증 및 운영 코드 refactor

### DIFF
--- a/src/main/java/com/ktcloud/daangn/common/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/ktcloud/daangn/common/exception/CustomExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.net.BindException;
 import java.security.SignatureException;
+import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
@@ -39,9 +40,9 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     protected ResponseEntity<BaseResponse<String>> dataIntegrityViolationException(DataIntegrityViolationException e) {
-        String message = e.getMessage();
+        Throwable cause = e.getCause();
 
-        if(message != null && message.contains("uk_tran_type"))
+        if (cause instanceof SQLException sqlEx && "23000".equals(sqlEx.getSQLState()))
             return ResponseEntity.status(ResultCode.BAD_REQUEST.getStatusCode())
                     .body(BaseResponse.fail(HttpStatus.BAD_REQUEST.value(), "이미 진행된 거래입니다.", null));
 

--- a/src/main/java/com/ktcloud/daangn/common/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/ktcloud/daangn/common/exception/CustomExceptionHandler.java
@@ -16,7 +16,6 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.net.BindException;
 import java.security.SignatureException;
-import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
@@ -40,15 +39,9 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     protected ResponseEntity<BaseResponse<String>> dataIntegrityViolationException(DataIntegrityViolationException e) {
-        Throwable cause = e.getCause();
-
-        if (cause instanceof SQLException sqlEx && "23000".equals(sqlEx.getSQLState()))
-            return ResponseEntity.status(ResultCode.BAD_REQUEST.getStatusCode())
-                    .body(BaseResponse.fail(HttpStatus.BAD_REQUEST.value(), "이미 진행된 거래입니다.", null));
-
         return ResponseEntity
                 .status(ResultCode.BAD_REQUEST.getStatusCode())
-                .body(BaseResponse.fail(HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다.", null));
+                .body(BaseResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR.value(), "잘못된 요청입니다.", null));
     }
 
     /// 매개변수 값이 올바르게 처리 되지 않았을때 에러처리

--- a/src/main/java/com/ktcloud/daangn/common/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/ktcloud/daangn/common/exception/CustomExceptionHandler.java
@@ -41,7 +41,7 @@ public class CustomExceptionHandler {
     protected ResponseEntity<BaseResponse<String>> dataIntegrityViolationException(DataIntegrityViolationException e) {
         return ResponseEntity
                 .status(ResultCode.BAD_REQUEST.getStatusCode())
-                .body(BaseResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR.value(), "잘못된 요청입니다.", null));
+                .body(BaseResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR.value(), "필수 값이 누락되었거나 형식이 올바르지 않습니다.", null));
     }
 
     /// 매개변수 값이 올바르게 처리 되지 않았을때 에러처리

--- a/src/main/java/com/ktcloud/daangn/common/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/ktcloud/daangn/common/exception/CustomExceptionHandler.java
@@ -3,6 +3,7 @@ package com.ktcloud.daangn.common.exception;
 import com.ktcloud.daangn.common.ResultCode;
 import com.ktcloud.daangn.common.dto.BaseResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -34,6 +35,19 @@ public class CustomExceptionHandler {
         return ResponseEntity
                 .status(ResultCode.VALIDATION_FAILED.getStatusCode())
                 .body(new BaseResponse<>(ResultCode.VALIDATION_FAILED.getStatusCode(), LocalDateTime.now(), ResultCode.VALIDATION_FAILED.getMessage(), validationErrors));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    protected ResponseEntity<BaseResponse<String>> dataIntegrityViolationException(DataIntegrityViolationException e) {
+        String message = e.getMessage();
+
+        if(message != null && message.contains("uk_tran_type"))
+            return ResponseEntity.status(ResultCode.BAD_REQUEST.getStatusCode())
+                    .body(BaseResponse.fail(HttpStatus.BAD_REQUEST.value(), "이미 진행된 거래입니다.", null));
+
+        return ResponseEntity
+                .status(ResultCode.BAD_REQUEST.getStatusCode())
+                .body(BaseResponse.fail(HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다.", null));
     }
 
     /// 매개변수 값이 올바르게 처리 되지 않았을때 에러처리

--- a/src/main/java/com/ktcloud/daangn/member/repository/MemberDBRepository.java
+++ b/src/main/java/com/ktcloud/daangn/member/repository/MemberDBRepository.java
@@ -2,7 +2,9 @@ package com.ktcloud.daangn.member.repository;
 
 import com.ktcloud.daangn.member.entity.Member;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -39,5 +41,10 @@ public class MemberDBRepository implements MemberRepository {
                 .getResultList()
                 .stream()
                 .findFirst();
+    }
+
+    @Override
+    public Optional<Member> findByIdWithLock(Long id) {
+        return Optional.ofNullable(em.find(Member.class, id, LockModeType.PESSIMISTIC_WRITE));
     }
 }

--- a/src/main/java/com/ktcloud/daangn/member/repository/MemberDBRepository.java
+++ b/src/main/java/com/ktcloud/daangn/member/repository/MemberDBRepository.java
@@ -4,7 +4,6 @@ import com.ktcloud.daangn.member.entity.Member;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;

--- a/src/main/java/com/ktcloud/daangn/member/repository/MemberRepository.java
+++ b/src/main/java/com/ktcloud/daangn/member/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository {
     Optional<Member> findById(Long id);
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByIdWithLock(Long id);
 }

--- a/src/main/java/com/ktcloud/daangn/member/service/MemberService.java
+++ b/src/main/java/com/ktcloud/daangn/member/service/MemberService.java
@@ -16,4 +16,6 @@ public interface MemberService {
     Optional<Member> getByEmail(String email);
 
     MemberInfoResponseDto getMyInfo(Long id);
+
+    Member getByIdOrThrowWithLock(Long id);
 }

--- a/src/main/java/com/ktcloud/daangn/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/member/service/MemberServiceImpl.java
@@ -42,4 +42,10 @@ public class MemberServiceImpl implements MemberService{
         Member findMember = getByIdOrThrow(id);
         return MemberInfoResponseDto.from(findMember);
     }
+
+    @Override
+    public Member getByIdOrThrowWithLock(Long id) {
+        return memberRepository.findByIdWithLock(id)
+                .orElseThrow(() -> new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "존재하지 않은 ID입니다."));
+    }
 }

--- a/src/main/java/com/ktcloud/daangn/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/member/service/MemberServiceImpl.java
@@ -46,6 +46,6 @@ public class MemberServiceImpl implements MemberService{
     @Override
     public Member getByIdOrThrowWithLock(Long id) {
         return memberRepository.findByIdWithLock(id)
-                .orElseThrow(() -> new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "존재하지 않은 ID입니다."));
+                .orElseThrow(() -> new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 ID입니다."));
     }
 }

--- a/src/main/java/com/ktcloud/daangn/payment/controller/PaymentController.java
+++ b/src/main/java/com/ktcloud/daangn/payment/controller/PaymentController.java
@@ -33,16 +33,14 @@ public class PaymentController {
     }
 
     @GetMapping("/links/{tx}")
-    public BaseResponse<PaymentTradeResponse> detail(@PathVariable String tx) {
-        PaymentTokenDto dto = PaymentTokenDto.parse(tx);
-        return BaseResponse.success(new PaymentTradeResponse(dto.postId(), dto.tranSeqNo(), dto.amount()));
+    public BaseResponse<PaymentTokenDto> detail(@PathVariable String tx) {
+        return BaseResponse.success(paymentService.getTokenInfo(tx));
     }
 
     @PostMapping("/links/{tx}")
     public BaseResponse<PaymentResponseDto> confirmPayment(@AuthenticationPrincipal CustomUser user, @PathVariable String tx) {
         Long fromMemberId = user.getMemberId();
-        PaymentTokenDto dto = PaymentTokenDto.parse(tx);
-        return BaseResponse.success(paymentService.confirmPayment(fromMemberId, dto));
+        return BaseResponse.success(paymentService.confirmPayment(fromMemberId, tx));
     }
 
 }

--- a/src/main/java/com/ktcloud/daangn/payment/controller/PaymentController.java
+++ b/src/main/java/com/ktcloud/daangn/payment/controller/PaymentController.java
@@ -27,8 +27,9 @@ public class PaymentController {
     }
 
     @PostMapping("/links")
-    public BaseResponse<String> create(@Valid @RequestBody PaymentInitRequestDto dto) {
-        return BaseResponse.success(paymentService.requestPayment(dto));
+    public BaseResponse<String> create(@AuthenticationPrincipal CustomUser user, @Valid @RequestBody PaymentInitRequestDto dto) {
+        paymentService.requestPayment(user.getMemberId(), dto);
+        return BaseResponse.success("거래 생성 성공");
     }
 
     @GetMapping("/links/{tx}")

--- a/src/main/java/com/ktcloud/daangn/payment/controller/PaymentController.java
+++ b/src/main/java/com/ktcloud/daangn/payment/controller/PaymentController.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
@@ -33,12 +35,12 @@ public class PaymentController {
     }
 
     @GetMapping("/links/{tx}")
-    public BaseResponse<PaymentTokenDto> detail(@PathVariable String tx) {
+    public BaseResponse<PaymentTokenDto> detail(@PathVariable UUID tx) {
         return BaseResponse.success(paymentService.getTokenInfo(tx));
     }
 
     @PostMapping("/links/{tx}")
-    public BaseResponse<PaymentResponseDto> confirmPayment(@AuthenticationPrincipal CustomUser user, @PathVariable String tx) {
+    public BaseResponse<PaymentResponseDto> confirmPayment(@AuthenticationPrincipal CustomUser user, @PathVariable UUID tx) {
         Long fromMemberId = user.getMemberId();
         return BaseResponse.success(paymentService.confirmPayment(fromMemberId, tx));
     }

--- a/src/main/java/com/ktcloud/daangn/payment/dto/PaymentInitRequestDto.java
+++ b/src/main/java/com/ktcloud/daangn/payment/dto/PaymentInitRequestDto.java
@@ -1,8 +1,13 @@
 package com.ktcloud.daangn.payment.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record PaymentInitRequestDto(
+        @NotBlank
         Long roomId,
+        @NotBlank
         Long postId,
+        @NotBlank
         Long amount
 ) {
 }

--- a/src/main/java/com/ktcloud/daangn/payment/dto/PaymentInitRequestDto.java
+++ b/src/main/java/com/ktcloud/daangn/payment/dto/PaymentInitRequestDto.java
@@ -1,6 +1,7 @@
 package com.ktcloud.daangn.payment.dto;
 
 public record PaymentInitRequestDto(
+        Long roomId,
         Long postId,
         Long amount
 ) {

--- a/src/main/java/com/ktcloud/daangn/payment/dto/PaymentRequestDto.java
+++ b/src/main/java/com/ktcloud/daangn/payment/dto/PaymentRequestDto.java
@@ -2,6 +2,7 @@ package com.ktcloud.daangn.payment.dto;
 
 import com.ktcloud.daangn.member.entity.Member;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
+import com.ktcloud.daangn.payment.entity.PaymentStatus;
 
 import java.time.LocalDateTime;
 
@@ -15,7 +16,7 @@ public record PaymentRequestDto(
                 .member(member)
                 .tranSeqNo(tran_seq_no)
                 .changedCash(tran_amt)
-                .type(add ? "입금" : "출금")
+                .type(add ? PaymentStatus.DEPOSIT.getMessage() : PaymentStatus.WITHDRAWAL.getMessage())
                 .balance(member.getBalance())
                 .localDateTime(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/ktcloud/daangn/payment/dto/PaymentRequestDto.java
+++ b/src/main/java/com/ktcloud/daangn/payment/dto/PaymentRequestDto.java
@@ -16,7 +16,7 @@ public record PaymentRequestDto(
                 .member(member)
                 .tranSeqNo(tran_seq_no)
                 .changedCash(tran_amt)
-                .type(add ? PaymentStatus.DEPOSIT.getMessage() : PaymentStatus.WITHDRAWAL.getMessage())
+                .type(add ? PaymentStatus.DEPOSIT : PaymentStatus.WITHDRAWAL)
                 .balance(member.getBalance())
                 .localDateTime(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/ktcloud/daangn/payment/dto/PaymentRequestDto.java
+++ b/src/main/java/com/ktcloud/daangn/payment/dto/PaymentRequestDto.java
@@ -3,12 +3,16 @@ package com.ktcloud.daangn.payment.dto;
 import com.ktcloud.daangn.member.entity.Member;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
 import com.ktcloud.daangn.payment.entity.PaymentStatus;
+import jakarta.validation.constraints.NotBlank;
 
 import java.time.LocalDateTime;
 
 public record PaymentRequestDto(
+        @NotBlank
         String tran_seq_no,
+        @NotBlank
         Long tran_amt,
+        @NotBlank
         Long memberId
 ) {
     public PaymentHistory to(Member member, boolean add){

--- a/src/main/java/com/ktcloud/daangn/payment/dto/PaymentRequestDto.java
+++ b/src/main/java/com/ktcloud/daangn/payment/dto/PaymentRequestDto.java
@@ -6,10 +6,11 @@ import com.ktcloud.daangn.payment.entity.PaymentStatus;
 import jakarta.validation.constraints.NotBlank;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record PaymentRequestDto(
         @NotBlank
-        String tran_seq_no,
+        UUID tran_seq_no,
         @NotBlank
         Long tran_amt,
         @NotBlank

--- a/src/main/java/com/ktcloud/daangn/payment/dto/PaymentTokenDto.java
+++ b/src/main/java/com/ktcloud/daangn/payment/dto/PaymentTokenDto.java
@@ -1,23 +1,15 @@
 package com.ktcloud.daangn.payment.dto;
 
-import com.ktcloud.daangn.common.exception.InvalidInputException;
-import org.springframework.http.HttpStatus;
+import com.ktcloud.daangn.payment.entity.PaymentToken;
 
-import static java.lang.Long.*;
+import java.util.UUID;
 
 public record PaymentTokenDto(
-        String tranSeqNo,
+        UUID tranSeqNo,
         Long amount,
         Long postId
 ) {
-    public static PaymentTokenDto parse(String tx) {
-        String[] parts = tx.split("_");
-        if (parts.length != 3) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 uri입니다.");
-
-        return new PaymentTokenDto(
-                parts[0],
-                parseLong(parts[1]),
-                parseLong(parts[2])
-        );
+    public static PaymentTokenDto from(PaymentToken token) {
+        return new PaymentTokenDto(token.tranSeqNo, token.amount, token.postId);
     }
 }

--- a/src/main/java/com/ktcloud/daangn/payment/entity/PaymentHistory.java
+++ b/src/main/java/com/ktcloud/daangn/payment/entity/PaymentHistory.java
@@ -2,7 +2,6 @@ package com.ktcloud.daangn.payment.entity;
 
 import com.ktcloud.daangn.member.entity.Member;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,23 +27,23 @@ public class PaymentHistory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id",nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
-    @NotNull
+    @Column(nullable = false)
     private String tranSeqNo;
 
-    @NotNull
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private PaymentStatus type;
 
-    @NotNull
+    @Column(nullable = false)
     private Long changedCash;
 
-    @NotNull
+    @Column(nullable = false)
     private Long balance;
 
-    @NotNull
+    @Column(nullable = false)
     private LocalDateTime localDateTime;
 }

--- a/src/main/java/com/ktcloud/daangn/payment/entity/PaymentHistory.java
+++ b/src/main/java/com/ktcloud/daangn/payment/entity/PaymentHistory.java
@@ -26,7 +26,8 @@ public class PaymentHistory {
 
     private String tranSeqNo;
 
-    private String type;
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus type;
 
     private Long changedCash;
 

--- a/src/main/java/com/ktcloud/daangn/payment/entity/PaymentHistory.java
+++ b/src/main/java/com/ktcloud/daangn/payment/entity/PaymentHistory.java
@@ -14,6 +14,13 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(
+        name = "payment_history",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_tran_type",
+                columnNames = {"tran_seq_no","type"}
+        )
+)
 public class PaymentHistory {
 
     @Id

--- a/src/main/java/com/ktcloud/daangn/payment/entity/PaymentHistory.java
+++ b/src/main/java/com/ktcloud/daangn/payment/entity/PaymentHistory.java
@@ -2,6 +2,7 @@ package com.ktcloud.daangn.payment.entity;
 
 import com.ktcloud.daangn.member.entity.Member;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,14 +32,19 @@ public class PaymentHistory {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
+    @NotNull
     private String tranSeqNo;
 
+    @NotNull
     @Enumerated(EnumType.STRING)
     private PaymentStatus type;
 
+    @NotNull
     private Long changedCash;
 
+    @NotNull
     private Long balance;
 
+    @NotNull
     private LocalDateTime localDateTime;
 }

--- a/src/main/java/com/ktcloud/daangn/payment/entity/PaymentHistory.java
+++ b/src/main/java/com/ktcloud/daangn/payment/entity/PaymentHistory.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -32,7 +33,7 @@ public class PaymentHistory {
     private Member member;
 
     @Column(nullable = false)
-    private String tranSeqNo;
+    private UUID tranSeqNo;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/ktcloud/daangn/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/ktcloud/daangn/payment/entity/PaymentStatus.java
@@ -1,0 +1,13 @@
+package com.ktcloud.daangn.payment.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentStatus {
+    DEPOSIT("입금"),
+    WITHDRAWAL("출금");
+
+    private final String message;
+}

--- a/src/main/java/com/ktcloud/daangn/payment/entity/PaymentToken.java
+++ b/src/main/java/com/ktcloud/daangn/payment/entity/PaymentToken.java
@@ -1,0 +1,44 @@
+package com.ktcloud.daangn.payment.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "payment_links")
+public class PaymentToken {
+
+    @Id
+    @Column(columnDefinition = "BINARY(16)")
+    public UUID tranSeqNo;
+
+    @Column(nullable = false)
+    public Long postId;
+
+    @Column(nullable = false)
+    public Long sellerId;
+
+    @Column(nullable = false)
+    public Long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    public PaymentTokenStatus status;
+
+    public void markAsCompleted() {
+        this.status = PaymentTokenStatus.COMPLETED;
+    }
+
+    public boolean isCompleted() {
+        return this.status == PaymentTokenStatus.COMPLETED;
+    }
+}
+

--- a/src/main/java/com/ktcloud/daangn/payment/entity/PaymentTokenStatus.java
+++ b/src/main/java/com/ktcloud/daangn/payment/entity/PaymentTokenStatus.java
@@ -1,0 +1,5 @@
+package com.ktcloud.daangn.payment.entity;
+
+public enum PaymentTokenStatus {
+    PENDING, COMPLETED
+}

--- a/src/main/java/com/ktcloud/daangn/payment/repository/PaymentDBRepository.java
+++ b/src/main/java/com/ktcloud/daangn/payment/repository/PaymentDBRepository.java
@@ -5,6 +5,8 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
 @Repository
 @RequiredArgsConstructor
 public class PaymentDBRepository implements PaymentRepository{
@@ -17,7 +19,7 @@ public class PaymentDBRepository implements PaymentRepository{
     }
 
     @Override
-    public Boolean existsByTranSeqNo(String tranSeqNo) {
+    public Boolean existsByTranSeqNo(UUID tranSeqNo) {
         return !em.createQuery("select p from PaymentHistory p where p.tranSeqNo = :tranSeqNo", PaymentHistory.class)
                 .setParameter("tranSeqNo", tranSeqNo)
                 .getResultList()

--- a/src/main/java/com/ktcloud/daangn/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/ktcloud/daangn/payment/repository/PaymentRepository.java
@@ -2,9 +2,11 @@ package com.ktcloud.daangn.payment.repository;
 
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
 
+import java.util.UUID;
+
 public interface PaymentRepository {
 
     void save(PaymentHistory paymentHistory);
 
-    Boolean existsByTranSeqNo(String tranSeqNo);
+    Boolean existsByTranSeqNo(UUID tranSeqNo);
 }

--- a/src/main/java/com/ktcloud/daangn/payment/repository/PaymentTokenDBRepository.java
+++ b/src/main/java/com/ktcloud/daangn/payment/repository/PaymentTokenDBRepository.java
@@ -1,0 +1,26 @@
+package com.ktcloud.daangn.payment.repository;
+
+import com.ktcloud.daangn.payment.entity.PaymentToken;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentTokenDBRepository implements PaymentTokenRepository {
+
+    private final EntityManager em;
+
+    @Override
+    public void save(PaymentToken paymentToken) {
+        em.persist(paymentToken);
+    }
+
+    @Override
+    public Optional<PaymentToken> getToken(UUID tranSeqNo) {
+        return Optional.ofNullable(em.find(PaymentToken.class, tranSeqNo));
+    }
+}

--- a/src/main/java/com/ktcloud/daangn/payment/repository/PaymentTokenDBRepository.java
+++ b/src/main/java/com/ktcloud/daangn/payment/repository/PaymentTokenDBRepository.java
@@ -2,6 +2,7 @@ package com.ktcloud.daangn.payment.repository;
 
 import com.ktcloud.daangn.payment.entity.PaymentToken;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -22,5 +23,10 @@ public class PaymentTokenDBRepository implements PaymentTokenRepository {
     @Override
     public Optional<PaymentToken> getToken(UUID tranSeqNo) {
         return Optional.ofNullable(em.find(PaymentToken.class, tranSeqNo));
+    }
+
+    @Override
+    public Optional<PaymentToken> getTokenWithLock(UUID tranSeqNo) {
+        return Optional.ofNullable(em.find(PaymentToken.class, tranSeqNo, LockModeType.PESSIMISTIC_WRITE));
     }
 }

--- a/src/main/java/com/ktcloud/daangn/payment/repository/PaymentTokenRepository.java
+++ b/src/main/java/com/ktcloud/daangn/payment/repository/PaymentTokenRepository.java
@@ -1,0 +1,13 @@
+package com.ktcloud.daangn.payment.repository;
+
+import com.ktcloud.daangn.payment.entity.PaymentToken;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentTokenRepository {
+
+    void save(PaymentToken paymentToken);
+
+    Optional<PaymentToken> getToken(UUID tranSeqNo);
+}

--- a/src/main/java/com/ktcloud/daangn/payment/repository/PaymentTokenRepository.java
+++ b/src/main/java/com/ktcloud/daangn/payment/repository/PaymentTokenRepository.java
@@ -10,4 +10,6 @@ public interface PaymentTokenRepository {
     void save(PaymentToken paymentToken);
 
     Optional<PaymentToken> getToken(UUID tranSeqNo);
+
+    Optional<PaymentToken> getTokenWithLock(UUID tranSeqNo);
 }

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentService.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentService.java
@@ -5,15 +5,17 @@ import com.ktcloud.daangn.payment.dto.PaymentRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentResponseDto;
 import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
 
+import java.util.UUID;
+
 public interface PaymentService {
 
     PaymentResponseDto deposit(PaymentRequestDto dto);
 
     PaymentResponseDto withdraw(PaymentRequestDto dto);
 
-    PaymentResponseDto confirmPayment(Long fromMemberId, String tx);
+    PaymentResponseDto confirmPayment(Long fromMemberId, UUID tx);
 
     void requestPayment(Long sellerId,PaymentInitRequestDto dto);
 
-    PaymentTokenDto getTokenInfo(String token);
+    PaymentTokenDto getTokenInfo(UUID token);
 }

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentService.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentService.java
@@ -13,5 +13,5 @@ public interface PaymentService {
 
     PaymentResponseDto confirmPayment(Long fromMemberId, PaymentTokenDto dto);
 
-    String requestPayment(PaymentInitRequestDto dto);
+    void requestPayment(Long sellerId,PaymentInitRequestDto dto);
 }

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentService.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentService.java
@@ -11,7 +11,9 @@ public interface PaymentService {
 
     PaymentResponseDto withdraw(PaymentRequestDto dto);
 
-    PaymentResponseDto confirmPayment(Long fromMemberId, PaymentTokenDto dto);
+    PaymentResponseDto confirmPayment(Long fromMemberId, String tx);
 
     void requestPayment(Long sellerId,PaymentInitRequestDto dto);
+
+    PaymentTokenDto getTokenInfo(String token);
 }

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
@@ -9,6 +9,7 @@ import com.ktcloud.daangn.payment.dto.PaymentRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentResponseDto;
 import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
+import com.ktcloud.daangn.payment.entity.PaymentStatus;
 import com.ktcloud.daangn.payment.repository.PaymentRepository;
 import com.ktcloud.daangn.post.entity.Post;
 import com.ktcloud.daangn.post.entity.PostStatus;
@@ -64,14 +65,14 @@ public class PaymentServiceImpl implements PaymentService {
         if (fromMemberId.equals(post.getMemberId())) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 접근입니다.");
         if (post.getStatus().equals(PostStatus.SOLD)) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 판매된 제품입니다.");
 
-        Member targetMember = memberService.getByIdOrThrow(post.getMember().getId());
-        Member fromMember = memberService.getByIdOrThrow(fromMemberId);
+        Member targetMember = memberService.getByIdOrThrowWithLock(post.getMember().getId());
+        Member fromMember = memberService.getByIdOrThrowWithLock(fromMemberId);
 
         fromMember.changeBalance(false, dto.amount());
         targetMember.changeBalance(true, dto.amount());
 
         PaymentHistory fromMemberHistory = PaymentHistory.builder()
-                .type("출금")
+                .type(PaymentStatus.WITHDRAWAL)
                 .localDateTime(LocalDateTime.now())
                 .member(fromMember)
                 .balance(fromMember.getBalance())
@@ -80,7 +81,7 @@ public class PaymentServiceImpl implements PaymentService {
                 .build();
 
         PaymentHistory targetMemberHistory = PaymentHistory.builder()
-                .type("입금")
+                .type(PaymentStatus.DEPOSIT)
                 .localDateTime(LocalDateTime.now())
                 .member(targetMember)
                 .balance(targetMember.getBalance())

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
@@ -61,12 +61,19 @@ public class PaymentServiceImpl implements PaymentService {
     public PaymentResponseDto confirmPayment(Long fromMemberId, PaymentTokenDto dto) {
         if (paymentRepository.existsByTranSeqNo(dto.tranSeqNo())) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 진행된 거래입니다.");
         Post post = postService.getPostOrThrow(dto.postId());
+        Long targetMemberId = post.getMemberId();
 
-        if (fromMemberId.equals(post.getMemberId())) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 접근입니다.");
+        if (fromMemberId.equals(targetMemberId)) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 접근입니다.");
         if (post.getStatus().equals(PostStatus.SOLD)) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 판매된 제품입니다.");
 
-        Member targetMember = memberService.getByIdOrThrowWithLock(post.getMember().getId());
-        Member fromMember = memberService.getByIdOrThrowWithLock(fromMemberId);
+        Member fromMember, targetMember;
+        if (fromMemberId < targetMemberId) {
+            fromMember = memberService.getByIdOrThrowWithLock(fromMemberId);
+            targetMember = memberService.getByIdOrThrowWithLock(targetMemberId);
+        } else {
+            targetMember = memberService.getByIdOrThrowWithLock(targetMemberId);
+            fromMember = memberService.getByIdOrThrowWithLock(fromMemberId);
+        }
 
         fromMember.changeBalance(false, dto.amount());
         targetMember.changeBalance(true, dto.amount());

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
@@ -60,7 +60,7 @@ public class PaymentServiceImpl implements PaymentService {
     @Override
     public PaymentResponseDto confirmPayment(Long fromMemberId, PaymentTokenDto dto) {
         if (paymentRepository.existsByTranSeqNo(dto.tranSeqNo())) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 진행된 거래입니다.");
-        Post post = postService.getPostOrThrow(dto.postId());
+        Post post = postService.getPostOrThrowWithLock(dto.postId());
         Long targetMemberId = post.getMemberId();
 
         if (fromMemberId.equals(targetMemberId)) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 접근입니다.");

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
@@ -66,8 +66,8 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
-    public PaymentResponseDto confirmPayment(Long fromMemberId, String tx) {
-        PaymentToken paymentToken = paymentTokenRepository.getToken(UUID.fromString(tx))
+    public PaymentResponseDto confirmPayment(Long fromMemberId, UUID tx) {
+        PaymentToken paymentToken = paymentTokenRepository.getToken(tx)
                 .orElseThrow(() -> new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 접근입니다."));
         if (paymentToken.isCompleted()) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 진행된 거래입니다.");
         PaymentTokenDto dto = PaymentTokenDto.from(paymentToken);
@@ -139,8 +139,7 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
-    public PaymentTokenDto getTokenInfo(String tokenString) {
-        UUID token = UUID.fromString(tokenString);
+    public PaymentTokenDto getTokenInfo(UUID token) {
         PaymentToken findToken = paymentTokenRepository.getToken(token)
                 .orElseThrow(() -> new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 링크입니다."));
         return PaymentTokenDto.from(findToken);

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
@@ -67,7 +67,7 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     public PaymentResponseDto confirmPayment(Long fromMemberId, UUID tx) {
-        PaymentToken paymentToken = paymentTokenRepository.getToken(tx)
+        PaymentToken paymentToken = paymentTokenRepository.getTokenWithLock(tx)
                 .orElseThrow(() -> new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 접근입니다."));
         if (paymentToken.isCompleted()) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 진행된 거래입니다.");
         PaymentTokenDto dto = PaymentTokenDto.from(paymentToken);
@@ -139,9 +139,11 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PaymentTokenDto getTokenInfo(UUID token) {
         PaymentToken findToken = paymentTokenRepository.getToken(token)
                 .orElseThrow(() -> new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 링크입니다."));
+        if (findToken.isCompleted()) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 진행된 거래입니다.");
         return PaymentTokenDto.from(findToken);
     }
 }

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ktcloud.daangn.payment.service;
 
 import com.github.f4b6a3.uuid.UuidCreator;
+import com.ktcloud.daangn.chat.service.ChatMessageService;
 import com.ktcloud.daangn.common.exception.InvalidInputException;
 import com.ktcloud.daangn.member.entity.Member;
 import com.ktcloud.daangn.member.service.MemberService;
@@ -30,6 +31,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final MemberService memberService;
     private final PaymentRepository paymentRepository;
     private final PostService postService;
+    private final ChatMessageService chatMessageService;
 
     @Override
     public PaymentResponseDto deposit(PaymentRequestDto dto) {
@@ -103,13 +105,16 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
-    public String requestPayment(PaymentInitRequestDto dto) {
+    public void requestPayment(Long sellerId,PaymentInitRequestDto dto) {
         Post post = postService.getPostOrThrow(dto.postId());
 
         if (post.getStatus().equals(PostStatus.SOLD)) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 판매된 제품입니다.");
 
         UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
         //todo 추후 amount과 postId는 외부로 노출 하지않는 방향으로 변경 예정
-        return tranSeqNo+"_"+dto.amount()+"_"+dto.postId();
+        String token = tranSeqNo + "_" + dto.amount() + "_" + dto.postId();
+
+        String message = "결제 링크입니다!\nhttp://localhost:8080/api/v1/payments/links/" + token;
+        chatMessageService.create(dto.roomId(), sellerId, message);
     }
 }

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
@@ -33,7 +33,6 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     public PaymentResponseDto deposit(PaymentRequestDto dto) {
-        //TODO 추후 Lock 관련 이슈 해결하기
         if (paymentRepository.existsByTranSeqNo(dto.tran_seq_no())) {
             throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 진행된 내역입니다.");
         }
@@ -46,7 +45,6 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     public PaymentResponseDto withdraw(PaymentRequestDto dto) {
-        //TODO 추후 Lock 관련 이슈 해결하기
         if (paymentRepository.existsByTranSeqNo(dto.tran_seq_no())) {
             throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 진행된 내역입니다.");
         }

--- a/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/payment/service/PaymentServiceImpl.java
@@ -11,11 +11,15 @@ import com.ktcloud.daangn.payment.dto.PaymentResponseDto;
 import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
 import com.ktcloud.daangn.payment.entity.PaymentStatus;
+import com.ktcloud.daangn.payment.entity.PaymentToken;
+import com.ktcloud.daangn.payment.entity.PaymentTokenStatus;
 import com.ktcloud.daangn.payment.repository.PaymentRepository;
+import com.ktcloud.daangn.payment.repository.PaymentTokenRepository;
 import com.ktcloud.daangn.post.entity.Post;
 import com.ktcloud.daangn.post.entity.PostStatus;
 import com.ktcloud.daangn.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +36,10 @@ public class PaymentServiceImpl implements PaymentService {
     private final PaymentRepository paymentRepository;
     private final PostService postService;
     private final ChatMessageService chatMessageService;
+    private final PaymentTokenRepository paymentTokenRepository;
+
+    @Value("${app.payment-link-base-url}")
+    private String paymentLinkBaseUrl;
 
     @Override
     public PaymentResponseDto deposit(PaymentRequestDto dto) {
@@ -58,8 +66,12 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
-    public PaymentResponseDto confirmPayment(Long fromMemberId, PaymentTokenDto dto) {
-        if (paymentRepository.existsByTranSeqNo(dto.tranSeqNo())) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 진행된 거래입니다.");
+    public PaymentResponseDto confirmPayment(Long fromMemberId, String tx) {
+        PaymentToken paymentToken = paymentTokenRepository.getToken(UUID.fromString(tx))
+                .orElseThrow(() -> new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 접근입니다."));
+        if (paymentToken.isCompleted()) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 진행된 거래입니다.");
+        PaymentTokenDto dto = PaymentTokenDto.from(paymentToken);
+
         Post post = postService.getPostOrThrowWithLock(dto.postId());
         Long targetMemberId = post.getMemberId();
 
@@ -97,6 +109,7 @@ public class PaymentServiceImpl implements PaymentService {
                 .build();
 
         post.markAsSold();
+        paymentToken.markAsCompleted();
 
         paymentRepository.save(fromMemberHistory);
         paymentRepository.save(targetMemberHistory);
@@ -111,10 +124,25 @@ public class PaymentServiceImpl implements PaymentService {
         if (post.getStatus().equals(PostStatus.SOLD)) throw new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "이미 판매된 제품입니다.");
 
         UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
-        //todo 추후 amount과 postId는 외부로 노출 하지않는 방향으로 변경 예정
-        String token = tranSeqNo + "_" + dto.amount() + "_" + dto.postId();
+        PaymentToken paymentToken = PaymentToken.builder()
+                .tranSeqNo(tranSeqNo)
+                .postId(dto.postId())
+                .sellerId(sellerId)
+                .amount(dto.amount())
+                .status(PaymentTokenStatus.PENDING)
+                .build();
 
-        String message = "결제 링크입니다!\nhttp://localhost:8080/api/v1/payments/links/" + token;
+        paymentTokenRepository.save(paymentToken);
+
+        String message = "결제 링크입니다!\n" + paymentLinkBaseUrl + "/api/v1/payments/links/" + tranSeqNo;
         chatMessageService.create(dto.roomId(), sellerId, message);
+    }
+
+    @Override
+    public PaymentTokenDto getTokenInfo(String tokenString) {
+        UUID token = UUID.fromString(tokenString);
+        PaymentToken findToken = paymentTokenRepository.getToken(token)
+                .orElseThrow(() -> new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "잘못된 링크입니다."));
+        return PaymentTokenDto.from(findToken);
     }
 }

--- a/src/main/java/com/ktcloud/daangn/post/repository/PostRepository.java
+++ b/src/main/java/com/ktcloud/daangn/post/repository/PostRepository.java
@@ -1,9 +1,18 @@
 package com.ktcloud.daangn.post.repository;
 
 import com.ktcloud.daangn.post.entity.Post;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Post p where p.id =:postId")
+    Optional<Post> findPostByIdWithLock(Long postId);
 }

--- a/src/main/java/com/ktcloud/daangn/post/service/PostService.java
+++ b/src/main/java/com/ktcloud/daangn/post/service/PostService.java
@@ -21,4 +21,6 @@ public interface PostService {
     String deletePost(Long postId, Long memberId);
 
     Post getPostOrThrow(Long postId);
+
+    Post getPostOrThrowWithLock(Long postId);
 }

--- a/src/main/java/com/ktcloud/daangn/post/service/PostServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/post/service/PostServiceImpl.java
@@ -88,6 +88,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    @Transactional
     public Post getPostOrThrowWithLock(Long postId) {
         return postRepository.findPostByIdWithLock(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));

--- a/src/main/java/com/ktcloud/daangn/post/service/PostServiceImpl.java
+++ b/src/main/java/com/ktcloud/daangn/post/service/PostServiceImpl.java
@@ -87,6 +87,12 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
     }
 
+    @Override
+    public Post getPostOrThrowWithLock(Long postId) {
+        return postRepository.findPostByIdWithLock(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+    }
+
     private void validateOwner(Post post, Long memberId) {
         if (!post.isOwner(memberId)) {
             throw new IllegalArgumentException("게시글 작성자만 처리할 수 있습니다.");

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,6 +37,8 @@ spring:
 #    redis:
 #      host: localhost
 #      port: 6379
+app:
+  payment-link-base-url: "http://localhost:8080"
 
 logging:
   pattern:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -38,6 +38,9 @@ spring:
 #      host: localhost
 #      port: 6379
 
+app:
+  payment-link-base-url: "http://52.78.206.32:8080"
+
 logging:
   pattern:
     console: "[%d{HH:mm:ss.SSS}][%-5level][%logger] - %msg%n"

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -16,6 +16,9 @@ spring:
     show-sql: true
     open-in-view: false
 
+app:
+  payment-link-base-url: "http://localhost:8080"
+
 logging:
   pattern:
     console: "[%d{HH:mm:ss.SSS}][%-5level][%logger.%method:line%line] - %msg%n"

--- a/src/test/java/com/ktcloud/daangn/notification/event/PaymentEventPublishingAspectTest.java
+++ b/src/test/java/com/ktcloud/daangn/notification/event/PaymentEventPublishingAspectTest.java
@@ -90,7 +90,7 @@ class PaymentEventPublishingAspectTest {
         @Test
         @DisplayName("[HAPPY] 결제 요청 대상에게 이벤트를 발행한다")
         void publishesPaymentRequestEvents() {
-            PaymentInitRequestDto dto = new PaymentInitRequestDto(SELLER_ID, POST_ID, AMOUNT);
+            PaymentInitRequestDto dto = new PaymentInitRequestDto(ROOM_ID, POST_ID, AMOUNT);
             given(contextResolver.resolvePaymentRequestTargets(POST_ID))
                     .willReturn(List.of(new PaymentNotificationContextResolver.PaymentRequestTarget(BUYER_ID, ROOM_ID)));
 
@@ -107,7 +107,7 @@ class PaymentEventPublishingAspectTest {
         @Test
         @DisplayName("[HAPPY] 결제 요청 대상이 없으면 이벤트를 발행하지 않는다")
         void doesNotPublishWhenTargetNotFound() {
-            PaymentInitRequestDto dto = new PaymentInitRequestDto(SELLER_ID, POST_ID, AMOUNT);
+            PaymentInitRequestDto dto = new PaymentInitRequestDto(ROOM_ID, POST_ID, AMOUNT);
             given(contextResolver.resolvePaymentRequestTargets(POST_ID)).willReturn(List.of());
 
             aspect.publishPaymentRequestEvents(dto);

--- a/src/test/java/com/ktcloud/daangn/notification/event/PaymentEventPublishingAspectTest.java
+++ b/src/test/java/com/ktcloud/daangn/notification/event/PaymentEventPublishingAspectTest.java
@@ -28,7 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -91,7 +90,7 @@ class PaymentEventPublishingAspectTest {
         @Test
         @DisplayName("[HAPPY] 결제 요청 대상에게 이벤트를 발행한다")
         void publishesPaymentRequestEvents() {
-            PaymentInitRequestDto dto = new PaymentInitRequestDto(POST_ID, AMOUNT);
+            PaymentInitRequestDto dto = new PaymentInitRequestDto(SELLER_ID, POST_ID, AMOUNT);
             given(contextResolver.resolvePaymentRequestTargets(POST_ID))
                     .willReturn(List.of(new PaymentNotificationContextResolver.PaymentRequestTarget(BUYER_ID, ROOM_ID)));
 
@@ -108,7 +107,7 @@ class PaymentEventPublishingAspectTest {
         @Test
         @DisplayName("[HAPPY] 결제 요청 대상이 없으면 이벤트를 발행하지 않는다")
         void doesNotPublishWhenTargetNotFound() {
-            PaymentInitRequestDto dto = new PaymentInitRequestDto(POST_ID, AMOUNT);
+            PaymentInitRequestDto dto = new PaymentInitRequestDto(SELLER_ID, POST_ID, AMOUNT);
             given(contextResolver.resolvePaymentRequestTargets(POST_ID)).willReturn(List.of());
 
             aspect.publishPaymentRequestEvents(dto);

--- a/src/test/java/com/ktcloud/daangn/notification/event/PaymentEventPublishingAspectTest.java
+++ b/src/test/java/com/ktcloud/daangn/notification/event/PaymentEventPublishingAspectTest.java
@@ -1,5 +1,6 @@
 package com.ktcloud.daangn.notification.event;
 
+import com.github.f4b6a3.uuid.UuidCreator;
 import com.ktcloud.daangn.common.valueObject.Address;
 import com.ktcloud.daangn.payment.dto.PaymentInitRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentRequestDto;
@@ -23,6 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -72,7 +74,8 @@ class PaymentEventPublishingAspectTest {
         @Test
         @DisplayName("[HAPPY] 충전 완료 이벤트를 발행한다")
         void publishesDepositCompleteEvent() {
-            PaymentRequestDto dto = new PaymentRequestDto("tran-1", AMOUNT, SELLER_ID);
+            UUID tranSeqNu = UuidCreator.getTimeOrderedEpoch();
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNu, AMOUNT, SELLER_ID);
 
             aspect.publishDepositCompleteEvent(dto);
 
@@ -123,7 +126,8 @@ class PaymentEventPublishingAspectTest {
         @Test
         @DisplayName("[HAPPY] 결제 완료 이벤트를 발행한다")
         void publishesPaymentCompleteEvent() {
-            PaymentTokenDto dto = new PaymentTokenDto("tran-2", AMOUNT, POST_ID);
+            UUID tranSeqNu = UuidCreator.getTimeOrderedEpoch();
+            PaymentTokenDto dto = new PaymentTokenDto(tranSeqNu, AMOUNT, POST_ID);
             given(postService.getPostOrThrow(POST_ID)).willReturn(post);
             given(contextResolver.resolveChatRoomId(SELLER_ID, BUYER_ID, POST_ID))
                     .willReturn(Optional.of(ROOM_ID));
@@ -141,7 +145,8 @@ class PaymentEventPublishingAspectTest {
         @Test
         @DisplayName("[HAPPY] 채팅방을 찾지 못하면 이벤트를 발행하지 않는다")
         void doesNotPublishWhenChatRoomNotFound() {
-            PaymentTokenDto dto = new PaymentTokenDto("tran-2", AMOUNT, POST_ID);
+            UUID tranSeqNu = UuidCreator.getTimeOrderedEpoch();
+            PaymentTokenDto dto = new PaymentTokenDto(tranSeqNu, AMOUNT, POST_ID);
             given(postService.getPostOrThrow(POST_ID)).willReturn(post);
             given(contextResolver.resolveChatRoomId(SELLER_ID, BUYER_ID, POST_ID))
                     .willReturn(Optional.empty());

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -45,7 +45,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
 
     private Long mainMemberId;
     private final List<Long> counterpartMemberIds = new ArrayList<>();
-    private final List<String> txIds = new ArrayList<>();
+    private final List<UUID> txIds = new ArrayList<>();
 
     @BeforeEach
     public void initMainMember(){
@@ -381,8 +381,8 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
 
             initPosts(List.of(memberAId, memberBId));
 
-            String txA = txIds.getFirst();
-            String txB = txIds.getLast();
+            UUID txA = txIds.getFirst();
+            UUID txB = txIds.getLast();
 
             ExecutorService executor = Executors.newFixedThreadPool(2);
             CountDownLatch startLatch = new CountDownLatch(1);
@@ -521,7 +521,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                 UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
                 PaymentToken paymentToken = new PaymentToken(tranSeqNo, targetPost.getId(), sellerId, POST_PRICE, PaymentTokenStatus.PENDING);
                 em.persist(paymentToken);
-                txIds.add(tranSeqNo.toString());
+                txIds.add(tranSeqNo);
             }
             em.flush();
             em.clear();

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -303,7 +303,6 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             ConcurrentLinkedQueue<Object> unexpectedErrors = new ConcurrentLinkedQueue<>();
 
             for (int i = 0; i < buyUserCount; i++) {
-                final int index = i;
                 executor.submit(() -> {
                     try {
                         startLatch.await();

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -22,10 +22,7 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -111,9 +108,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             }
             //when
             startLatch.countDown(); //동시 실행 시작
-            doneLatch.await(); // 모든 작업 종료 대기
+            boolean completed = doneLatch.await(10, TimeUnit.SECONDS); // 모든 작업 종료 대기
             executor.shutdown(); //executor 종료
             //then
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심").isTrue();
             em.clear();
             Member toMember = em.find(Member.class, mainMemberId);
             assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE + POST_PRICE * buyUserCount);
@@ -179,9 +177,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             }
             //when
             startLatch.countDown(); //동시 실행 시작
-            doneLatch.await(); // 모든 작업 종료 대기
+            boolean completed = doneLatch.await(10, TimeUnit.SECONDS); // 모든 작업 종료 대기
             executor.shutdown(); //executor 종료
             //then
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심");
             em.clear();
             Member toMember = em.find(Member.class, mainMemberId);
             assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE);
@@ -258,9 +257,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             }
             //when
             startLatch.countDown(); //동시 실행 시작
-            doneLatch.await(); // 모든 작업 종료 대기
+            boolean completed = doneLatch.await(10, TimeUnit.SECONDS); // 모든 작업 종료 대기
             executor.shutdown(); //executor 종료
             //then
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심");
             assertThat(unexpectedErrors).isEmpty();
             assertThat(successCount.get()).isEqualTo(1);
             assertThat(failCount.get()).isEqualTo(1);
@@ -327,9 +327,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             }
             //when
             startLatch.countDown(); //동시 실행 시작
-            doneLatch.await(); // 모든 작업 종료 대기
+            boolean completed = doneLatch.await(10, TimeUnit.SECONDS); // 모든 작업 종료 대기
             executor.shutdown(); //executor 종료
             //then
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심");
             assertThat(unexpectedErrors).isEmpty();
             assertThat(successCount.get()).isEqualTo(1);
             assertThat(failCount.get()).isEqualTo(1);
@@ -402,10 +403,11 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
 
             //when
             startLatch.countDown(); //동시 실행 시작
-            doneLatch.await(); // 모든 작업 종료 대기
+            boolean completed = doneLatch.await(10, TimeUnit.SECONDS); // 모든 작업 종료 대기
             executor.shutdown(); //executor 종료
 
             //then
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심");
             em.clear();
             Member memberA = em.find(Member.class, memberAId);
             Member memberB = em.find(Member.class, memberBId);
@@ -457,10 +459,11 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             }
             //when
             startLatch.countDown();
-            doneLatch.await();
-            executor.shutdown();
+            boolean completed = doneLatch.await(10, TimeUnit.SECONDS); // 모든 작업 종료 대기
+            executor.shutdown(); //executor 종료
 
             //then
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심");
             em.clear();
             List<Post> soldPosts = em.createQuery("select p from Post p where p.status = :status", Post.class)
                     .setParameter("status", PostStatus.SOLD)

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -1,0 +1,324 @@
+package com.ktcloud.daangn.payment.service;
+
+import com.ktcloud.daangn.common.valueObject.Address;
+import com.ktcloud.daangn.config.TestContainerConfig;
+import com.ktcloud.daangn.member.entity.Member;
+import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
+import com.ktcloud.daangn.payment.entity.PaymentHistory;
+import com.ktcloud.daangn.payment.entity.PaymentStatus;
+import com.ktcloud.daangn.post.entity.Post;
+import com.ktcloud.daangn.post.entity.PostStatus;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class PaymentServiceConcurrencyTest extends TestContainerConfig {
+
+    @Autowired PaymentService paymentService;
+    @Autowired EntityManager em;
+    @Autowired PlatformTransactionManager transactionManager;
+
+    private final Long POST_PRICE = 5000L;
+    private static final Long INITIAL_BALANCE = 5000L;
+    private static final String INITIAL_NAME = "테스트";
+    private static final Address ADDRESS = new Address("서울시", "동작구", "사당동");
+
+    private Long mainMemberId;
+    private final List<Long> counterpartMemberIds = new ArrayList<>();
+    private final List<Long> postIds = new ArrayList<>();
+
+    @BeforeEach
+    public void initMainMember(){
+        runInTx(() -> {
+            Member member = Member.builder()
+                    .email("test1@test.com")
+                    .nickName(INITIAL_NAME)
+                    .balance(INITIAL_BALANCE)
+                    .address(ADDRESS)
+                    .build();
+
+            em.persist(member);
+            em.flush();
+            mainMemberId = member.getId();
+            em.clear();
+        });
+    }
+
+    @AfterEach
+    public void clear() {
+        runInTx(() -> {
+            em.createQuery("delete from PaymentHistory").executeUpdate();
+            em.createQuery("delete from Post").executeUpdate();
+            em.createQuery("delete from Member").executeUpdate();
+        });
+    }
+
+    @Nested
+    @DisplayName("동시 판매")
+    class MultiBuyersToSingleSeller {
+
+        /**
+         * INITIAL_BALANCE 포함 모든 POST_PRICE의 값이 더해짐
+         * 따라서 모든 로직이 실행된 후 잔액은 INITIAL_BALANCE + (POST_PRICE * 100)이 된다.
+         */
+        @Test
+        @DisplayName("[동시성] n명이 한명의 게시물 n건 구매시 판매자의 잔액 검증")
+        public void confirmPayment_MultiBuyersSingleSeller_Success() throws Exception {
+            //given
+            List<Long> sellers = Collections.nCopies(100, mainMemberId);
+            initPosts(sellers);
+            initCounterpartMembers();
+
+            int buyUserCount = 100;
+            ExecutorService executor = Executors.newFixedThreadPool(buyUserCount);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(buyUserCount);
+
+            for (int i = 0; i < buyUserCount; i++) {
+                final int index = i;
+                String formattedIndex = String.format("%02d", index);
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        paymentService.confirmPayment(counterpartMemberIds.get(index), new PaymentTokenDto("TXN_" + formattedIndex, POST_PRICE, postIds.get(index)));
+                    } catch (Exception e) {
+                        System.out.println("e = " + e.getMessage());
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+            //when
+            startLatch.countDown(); //동시 실행 시작
+            doneLatch.await(); // 모든 작업 종료 대기
+            executor.shutdown(); //executor 종료
+            //then
+            Member toMember = em.find(Member.class, mainMemberId);
+            assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE + POST_PRICE * buyUserCount);
+
+            List<PaymentHistory> paymentHistoryList = em.createQuery("select p from PaymentHistory p where p.type = :type and p.member.id = :toMemberId", PaymentHistory.class)
+                    .setParameter("type", PaymentStatus.DEPOSIT.getMessage())
+                    .setParameter("toMemberId", mainMemberId)
+                    .getResultList();
+
+            assertThat(paymentHistoryList.size()).isEqualTo(buyUserCount);
+            Long totalAmount = 0L;
+
+            for (PaymentHistory paymentHistory : paymentHistoryList) {
+                totalAmount += paymentHistory.getChangedCash();
+            }
+
+            assertThat(totalAmount).isEqualTo(toMember.getBalance() - INITIAL_BALANCE);
+
+            List<Post> statusList = em.createQuery("select p from Post p where p.status = :status", Post.class)
+                    .setParameter("status", PostStatus.SOLD)
+                    .getResultList();
+
+            assertThat(statusList.size()).isEqualTo(buyUserCount);
+        }
+    }
+
+    @Nested
+    @DisplayName("동시 구매")
+    class SingleBuyerToMultiSellers {
+
+        private static final Long BUYER_INITIAL_BALANCE = 500_000L;
+
+        /**
+         * 구매자(mainMember)의 잔액을 BUYER_INITIAL_BALANCE를 통해 재설정 후 검증
+         * 따라서 모든 로직이 끝나면 INITIAL_BALANCE만 남도록 의도
+         */
+        @Test
+        @DisplayName("[동시성] 한명이 n명의 게시물 n건 구매시 구매자의 잔액 검증")
+        public void confirmPayment_SingleBuyerMultiSellers_Success() throws Exception {
+            //given
+            initCounterpartMembers();
+            initPosts(counterpartMemberIds);
+            settingMemberBalance();
+
+            int buyUserCount = 100;
+            ExecutorService executor = Executors.newFixedThreadPool(buyUserCount);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(buyUserCount);
+            for (int i = 0; i < buyUserCount; i++) {
+                final int index = i;
+                String formattedIndex = String.format("%02d", index);
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        paymentService.confirmPayment(mainMemberId, new PaymentTokenDto("TXN_" + formattedIndex, POST_PRICE, postIds.get(index)));
+                    } catch (Exception e) {
+                        System.out.println("e = " + e.getMessage());
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+            //when
+            startLatch.countDown(); //동시 실행 시작
+            doneLatch.await(); // 모든 작업 종료 대기
+            executor.shutdown(); //executor 종료
+            //then
+            Member toMember = em.find(Member.class, mainMemberId);
+            assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE);
+
+            List<PaymentHistory> paymentHistoryList = em.createQuery("select p from PaymentHistory p where p.type = :type and p.member.id = :toMemberId", PaymentHistory.class)
+                    .setParameter("type", PaymentStatus.WITHDRAWAL.getMessage())
+                    .setParameter("toMemberId", mainMemberId)
+                    .getResultList();
+
+            assertThat(paymentHistoryList.size()).isEqualTo(buyUserCount);
+            Long totalAmount = 0L;
+
+            for (PaymentHistory paymentHistory : paymentHistoryList) {
+                totalAmount += paymentHistory.getChangedCash();
+            }
+
+            assertThat(totalAmount).isEqualTo(BUYER_INITIAL_BALANCE);
+
+            List<Post> statusList = em.createQuery("select p from Post p where p.status = :status", Post.class)
+                    .setParameter("status", PostStatus.SOLD)
+                    .getResultList();
+
+            assertThat(statusList.size()).isEqualTo(buyUserCount);
+        }
+
+        private void settingMemberBalance() {
+            runInTx(() -> {
+                Member member = em.find(Member.class, mainMemberId);
+                member.changeBalance(true, BUYER_INITIAL_BALANCE);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("잔액 부족 동시 결제")
+    class InsufficientBalanceOnConcurrentPayment {
+
+        /**
+         * 의도적으로 INITIAL_BALANCE와 POST_PRICE가 같도록 함
+         * 따라서 한건만 결제가 되고, 다른 한건은 잔액 부족에 대한 검증
+         */
+        @Test
+        @DisplayName("[동시성] 잔액 부족 시 1건만 성공하고 나머지는 잔액부족 예외 발생")
+        public void confirmPayment_InsufficientBalance_PartialSuccess() throws Exception {
+            //given
+            initCounterpartMembers();
+            initPosts(counterpartMemberIds);
+
+            int buyUserCount = 2;
+            ExecutorService executor = Executors.newFixedThreadPool(buyUserCount);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(buyUserCount);
+            AtomicInteger successCount = new AtomicInteger();
+            AtomicInteger failCount = new AtomicInteger();
+            ConcurrentLinkedQueue<Object> unexpectedErrors = new ConcurrentLinkedQueue<>();
+
+            for (int i = 0; i < buyUserCount; i++) {
+                final int index = i;
+                String formattedIndex = String.format("%02d", index);
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        paymentService.confirmPayment(mainMemberId, new PaymentTokenDto("TXN_" + formattedIndex, POST_PRICE, postIds.get(index)));
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        if (!"잔액이 부족합니다.".equals(e.getMessage())) unexpectedErrors.add(e);
+                        failCount.incrementAndGet();
+                        System.out.println("e = " + e.getMessage());
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+            //when
+            startLatch.countDown(); //동시 실행 시작
+            doneLatch.await(); // 모든 작업 종료 대기
+            executor.shutdown(); //executor 종료
+            //then
+            assertThat(unexpectedErrors).isEmpty();
+            assertThat(successCount.get()).isEqualTo(1);
+            assertThat(failCount.get()).isEqualTo(1);
+
+            Member member = em.find(Member.class, mainMemberId);
+            assertThat(member.getBalance()).isEqualTo(0L);
+
+            List<PaymentHistory> paymentHistoryList = em.createQuery("select p from PaymentHistory p order by p.id asc", PaymentHistory.class)
+                    .getResultList();
+
+            assertThat(paymentHistoryList.size()).isEqualTo(2);
+
+            List<Post> soldPosts = em.createQuery("select p from Post p where p.status = :status", Post.class)
+                    .setParameter("status", PostStatus.SOLD)
+                    .getResultList();
+
+            assertThat(soldPosts).hasSize(1);
+        }
+    }
+
+    private void initCounterpartMembers() {
+        runInTx(() -> {
+            for (int i = 0; i < 100; i++) {
+                Member member = Member.builder()
+                        .email("test" + i + "@test.com")
+                        .nickName(INITIAL_NAME)
+                        .balance(INITIAL_BALANCE)
+                        .address(ADDRESS)
+                        .build();
+
+                em.persist(member);
+                counterpartMemberIds.add(member.getId());
+            }
+            em.flush();
+            em.clear();
+        });
+    }
+
+    private void initPosts(List<Long> sellerIds) {
+        runInTx(() -> {
+            for (Long sellerId : sellerIds) {
+                Member seller = em.find(Member.class, sellerId);
+                Post targetPost = new Post(seller, "제목", "내용", POST_PRICE, ADDRESS);
+                em.persist(targetPost);
+                System.out.println("targetPost.getId() = " + targetPost.getId());
+                postIds.add(targetPost.getId());
+            }
+            em.flush();
+            em.clear();
+        });
+    }
+
+    /**
+     * Spring Data JPA 사용하지 않아 직접 트랜잭션 관리를 해줘야함
+     * @param action
+     * 공통된 트랜잭션 관리를 진행하기 위해 runInTx메서드를 람다식을 사용하여 관리한다.
+     */
+    private void runInTx(Runnable action) {
+        TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
+        try {
+            action.run();
+            transactionManager.commit(status);
+        } catch (Exception e) {
+            transactionManager.rollback(status);
+            throw e;
+        }
+    }
+}

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -353,6 +353,73 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
         }
     }
 
+    @Nested
+    @DisplayName("상호 결제 시 데드락 검증")
+    class MutualPaymentBetweenTwoMembers {
+
+        @Test
+        @DisplayName("[동시성] A와 B가 서로의 게시물을 동시 결제 시 데드락 없이 정상 처리")
+        public void confirmPayment_MutualPayment_NoDeadlock() throws Exception {
+            //given
+            int buyUserCount = 1;
+
+            initCounterpartMembers(buyUserCount);
+            Long memberAId = mainMemberId;
+            Long memberBId = counterpartMemberIds.getFirst();
+
+            initPosts(List.of(memberAId,memberBId));
+            Long postA = postIds.getFirst();
+            Long postB = postIds.getLast();
+
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(2);
+
+            executor.submit(() -> { //A -> B
+                try {
+                    startLatch.await();
+                    paymentService.confirmPayment(memberAId, new PaymentTokenDto("TXN_A_TO_B" , POST_PRICE, postB));
+                } catch (Exception e) {
+                    System.out.println("e = " + e.getMessage());
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+
+            executor.submit(() -> { // B -> A
+                try {
+                    startLatch.await();
+                    paymentService.confirmPayment(memberBId, new PaymentTokenDto("TXN_B_TO_A" , POST_PRICE, postA));
+                } catch (Exception e) {
+                    System.out.println("e = " + e.getMessage());
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+
+            //when
+            startLatch.countDown(); //동시 실행 시작
+            doneLatch.await(); // 모든 작업 종료 대기
+            executor.shutdown(); //executor 종료
+
+            //then
+            em.clear();
+            Member memberA = em.find(Member.class, memberAId);
+            Member memberB = em.find(Member.class, memberBId);
+
+            assertThat(memberA.getBalance()).isEqualTo(INITIAL_BALANCE);
+            assertThat(memberB.getBalance()).isEqualTo(INITIAL_BALANCE);
+
+            List<PaymentHistory> histories = em.createQuery("select p from PaymentHistory p", PaymentHistory.class).getResultList();
+            assertThat(histories).hasSize(4);
+
+            List<Post> soldPosts = em.createQuery("select p from Post p where p.status = :status", Post.class)
+                    .setParameter("status", PostStatus.SOLD)
+                    .getResultList();
+            assertThat(soldPosts).hasSize(2);
+        }
+    }
+
     private void initCounterpartMembers(int userCount) {
         runInTx(() -> {
             for (int i = 0; i < userCount; i++) {
@@ -377,7 +444,6 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                 Member seller = em.find(Member.class, sellerId);
                 Post targetPost = new Post(seller, "제목", "내용", POST_PRICE, ADDRESS);
                 em.persist(targetPost);
-                System.out.println("targetPost.getId() = " + targetPost.getId());
                 postIds.add(targetPost.getId());
             }
             em.flush();

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -180,7 +180,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             boolean completed = doneLatch.await(10, TimeUnit.SECONDS); // 모든 작업 종료 대기
             executor.shutdown(); //executor 종료
             //then
-            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심");
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심").isTrue();
             em.clear();
             Member toMember = em.find(Member.class, mainMemberId);
             assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE);
@@ -247,7 +247,8 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                         paymentService.confirmPayment(mainMemberId, new PaymentTokenDto("TXN_" + formattedIndex, POST_PRICE, postIds.get(index)));
                         successCount.incrementAndGet();
                     } catch (Exception e) {
-                        if (!"잔액이 부족합니다.".equals(e.getMessage())) unexpectedErrors.add(e);
+                        boolean isExpected = e instanceof InvalidInputException && "잔액이 부족합니다.".equals(e.getMessage());
+                        if (!isExpected) unexpectedErrors.add(e);
                         failCount.incrementAndGet();
                         System.out.println("e = " + e.getMessage());
                     } finally {
@@ -260,8 +261,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             boolean completed = doneLatch.await(10, TimeUnit.SECONDS); // 모든 작업 종료 대기
             executor.shutdown(); //executor 종료
             //then
-            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심");
-            assertThat(unexpectedErrors).isEmpty();
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심").isTrue();
+            assertThat(unexpectedErrors)
+                    .as("예상치 못한 예외 발생: " + unexpectedErrors)
+                    .isEmpty();
             assertThat(successCount.get()).isEqualTo(1);
             assertThat(failCount.get()).isEqualTo(1);
 
@@ -330,8 +333,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             boolean completed = doneLatch.await(10, TimeUnit.SECONDS); // 모든 작업 종료 대기
             executor.shutdown(); //executor 종료
             //then
-            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심");
-            assertThat(unexpectedErrors).isEmpty();
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심").isTrue();
+            assertThat(unexpectedErrors)
+                    .as("예상치 못한 예외 발생: " + unexpectedErrors)
+                    .isEmpty();
             assertThat(successCount.get()).isEqualTo(1);
             assertThat(failCount.get()).isEqualTo(1);
 
@@ -407,7 +412,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             executor.shutdown(); //executor 종료
 
             //then
-            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심");
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심").isTrue();
             em.clear();
             Member memberA = em.find(Member.class, memberAId);
             Member memberB = em.find(Member.class, memberBId);
@@ -463,7 +468,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             executor.shutdown(); //executor 종료
 
             //then
-            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심");
+            assertThat(completed).as("동시성 작업 타임아웃 - 데드락 의심").isTrue();
             em.clear();
             List<Post> soldPosts = em.createQuery("select p from Post p where p.status = :status", Post.class)
                     .setParameter("status", PostStatus.SOLD)

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -113,6 +113,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             doneLatch.await(); // 모든 작업 종료 대기
             executor.shutdown(); //executor 종료
             //then
+            em.clear();
             Member toMember = em.find(Member.class, mainMemberId);
             assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE + POST_PRICE * buyUserCount);
 
@@ -180,6 +181,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             doneLatch.await(); // 모든 작업 종료 대기
             executor.shutdown(); //executor 종료
             //then
+            em.clear();
             Member toMember = em.find(Member.class, mainMemberId);
             assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE);
 
@@ -262,6 +264,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             assertThat(successCount.get()).isEqualTo(1);
             assertThat(failCount.get()).isEqualTo(1);
 
+            em.clear();
             Member member = em.find(Member.class, mainMemberId);
             assertThat(member.getBalance()).isEqualTo(0L);
 
@@ -326,6 +329,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             assertThat(successCount.get()).isEqualTo(1);
             assertThat(failCount.get()).isEqualTo(1);
 
+            em.clear();
             Member member = em.find(Member.class, mainMemberId);
             assertThat(member.getBalance()).isEqualTo(BUYER_INITIAL_BALANCE);
 

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -1,5 +1,6 @@
 package com.ktcloud.daangn.payment.service;
 
+import com.ktcloud.daangn.common.exception.InvalidInputException;
 import com.ktcloud.daangn.common.valueObject.Address;
 import com.ktcloud.daangn.config.TestContainerConfig;
 import com.ktcloud.daangn.member.entity.Member;
@@ -122,7 +123,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                     .setParameter("toMemberId", mainMemberId)
                     .getResultList();
 
-            assertThat(paymentHistoryList.size()).isEqualTo(buyUserCount);
+            assertThat(paymentHistoryList).hasSize(buyUserCount);
             Long totalAmount = 0L;
 
             for (PaymentHistory paymentHistory : paymentHistoryList) {
@@ -135,7 +136,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                     .setParameter("status", PostStatus.SOLD)
                     .getResultList();
 
-            assertThat(statusList.size()).isEqualTo(buyUserCount);
+            assertThat(statusList).hasSize(buyUserCount);
         }
     }
 
@@ -190,7 +191,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                     .setParameter("toMemberId", mainMemberId)
                     .getResultList();
 
-            assertThat(paymentHistoryList.size()).isEqualTo(buyUserCount);
+            assertThat(paymentHistoryList).hasSize(buyUserCount);
             Long totalAmount = 0L;
 
             for (PaymentHistory paymentHistory : paymentHistoryList) {
@@ -203,7 +204,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                     .setParameter("status", PostStatus.SOLD)
                     .getResultList();
 
-            assertThat(statusList.size()).isEqualTo(buyUserCount);
+            assertThat(statusList).hasSize(buyUserCount);
         }
 
         private void settingMemberBalance() {
@@ -271,7 +272,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             List<PaymentHistory> paymentHistoryList = em.createQuery("select p from PaymentHistory p order by p.id asc", PaymentHistory.class)
                     .getResultList();
 
-            assertThat(paymentHistoryList.size()).isEqualTo(2);
+            assertThat(paymentHistoryList).hasSize(2);
 
             List<Post> soldPosts = em.createQuery("select p from Post p where p.status = :status", Post.class)
                     .setParameter("status", PostStatus.SOLD)
@@ -312,7 +313,11 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                         paymentService.confirmPayment(mainMemberId, new PaymentTokenDto("TXN_11" , POST_PRICE, postIds.get(1))); //동일한 tranSeqNo
                         successCount.incrementAndGet();
                     } catch (Exception e) {
-                        if (!(e instanceof DataIntegrityViolationException)) unexpectedErrors.add(e);
+                        boolean isExpected = e instanceof DataIntegrityViolationException
+                                        || (e instanceof InvalidInputException &&
+                                        ("이미 진행된 거래입니다.".equals(e.getMessage()) || "이미 판매된 제품입니다.".equals(e.getMessage()))
+                        );
+                        if (!isExpected) unexpectedErrors.add(e);
                         failCount.incrementAndGet();
                         System.out.println("e = " + e.getMessage());
                     } finally {
@@ -331,17 +336,15 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
 
             em.clear();
             Member member = em.find(Member.class, mainMemberId);
-            assertThat(member.getBalance()).isEqualTo(BUYER_INITIAL_BALANCE);
+            assertThat(member.getBalance()).isEqualTo(BUYER_INITIAL_BALANCE); // 기존(INITIAL_BALANCE) + 추가 (BUYER_INITIAL_BALANCE) == 505_000L 따라서 결제 후 잔고 : 500_000L
 
             List<PaymentHistory> paymentHistoryList = em.createQuery("select p from PaymentHistory p order by p.id asc", PaymentHistory.class)
                     .getResultList();
-
-            assertThat(paymentHistoryList.size()).isEqualTo(2);
+            assertThat(paymentHistoryList).hasSize(2);
 
             List<Post> soldPosts = em.createQuery("select p from Post p where p.status = :status", Post.class)
                     .setParameter("status", PostStatus.SOLD)
                     .getResultList();
-
             assertThat(soldPosts).hasSize(1);
         }
 
@@ -417,6 +420,66 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                     .setParameter("status", PostStatus.SOLD)
                     .getResultList();
             assertThat(soldPosts).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("동일 게시물 동시 결제 시 이중 판매 방지")
+    class PreventDoubleSaleOnSamePost {
+
+        @Test
+        @DisplayName("[동시성] 두 명이 같은 게시물을 동시 결제 시 1명만 성공")
+        public void confirmPayment_DoubleSaleOnSamePost_OnlyOneSucceeds() throws Exception {
+            //given
+            int buyUserCount = 2;
+            initCounterpartMembers(buyUserCount);
+
+            initPosts(List.of(mainMemberId));
+            Long sharedPostId = postIds.getFirst();
+
+            ExecutorService executor = Executors.newFixedThreadPool(buyUserCount);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(buyUserCount);
+
+            for (int i = 0; i < buyUserCount; i++) {
+                final int index = i;
+                String formattedIndex = String.format("%02d", index);
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        paymentService.confirmPayment(counterpartMemberIds.get(index), new PaymentTokenDto("TXN_" + formattedIndex, POST_PRICE, sharedPostId));
+                    } catch (Exception e) {
+                        System.out.println("e = " + e.getMessage());
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+            //when
+            startLatch.countDown();
+            doneLatch.await();
+            executor.shutdown();
+
+            //then
+            em.clear();
+            List<Post> soldPosts = em.createQuery("select p from Post p where p.status = :status", Post.class)
+                    .setParameter("status", PostStatus.SOLD)
+                    .getResultList();
+            assertThat(soldPosts).hasSize(1);
+
+            Member seller = em.find(Member.class, mainMemberId);
+            assertThat(seller.getBalance()).isEqualTo(INITIAL_BALANCE + POST_PRICE);
+
+            Member buyer1 = em.find(Member.class, counterpartMemberIds.getFirst());
+            Member buyer2 = em.find(Member.class, counterpartMemberIds.getLast());
+
+            assertThat((buyer1.getBalance().equals(INITIAL_BALANCE - POST_PRICE) && buyer2.getBalance().equals(INITIAL_BALANCE)) ||
+                    (buyer2.getBalance().equals(INITIAL_BALANCE - POST_PRICE) && buyer1.getBalance().equals(INITIAL_BALANCE))
+            ).isTrue();
+
+            List<PaymentHistory> histories = em.createQuery("select p from PaymentHistory p", PaymentHistory.class)
+                    .getResultList();
+            assertThat(histories).hasSize(2);
         }
     }
 

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -1,12 +1,14 @@
 package com.ktcloud.daangn.payment.service;
 
+import com.github.f4b6a3.uuid.UuidCreator;
 import com.ktcloud.daangn.common.exception.InvalidInputException;
 import com.ktcloud.daangn.common.valueObject.Address;
 import com.ktcloud.daangn.config.TestContainerConfig;
 import com.ktcloud.daangn.member.entity.Member;
-import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
 import com.ktcloud.daangn.payment.entity.PaymentStatus;
+import com.ktcloud.daangn.payment.entity.PaymentToken;
+import com.ktcloud.daangn.payment.entity.PaymentTokenStatus;
 import com.ktcloud.daangn.post.entity.Post;
 import com.ktcloud.daangn.post.entity.PostStatus;
 import jakarta.persistence.EntityManager;
@@ -22,6 +24,7 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -42,7 +45,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
 
     private Long mainMemberId;
     private final List<Long> counterpartMemberIds = new ArrayList<>();
-    private final List<Long> postIds = new ArrayList<>();
+    private final List<String> txIds = new ArrayList<>();
 
     @BeforeEach
     public void initMainMember(){
@@ -64,10 +67,13 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
     @AfterEach
     public void clear() {
         runInTx(() -> {
+            em.createQuery("delete from PaymentToken").executeUpdate();
             em.createQuery("delete from PaymentHistory").executeUpdate();
             em.createQuery("delete from Post").executeUpdate();
             em.createQuery("delete from Member").executeUpdate();
         });
+        counterpartMemberIds.clear();
+        txIds.clear();
     }
 
     @Nested
@@ -94,11 +100,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
 
             for (int i = 0; i < buyUserCount; i++) {
                 final int index = i;
-                String formattedIndex = String.format("%02d", index);
                 executor.submit(() -> {
                     try {
                         startLatch.await();
-                        paymentService.confirmPayment(counterpartMemberIds.get(index), new PaymentTokenDto("TXN_" + formattedIndex, POST_PRICE, postIds.get(index)));
+                        paymentService.confirmPayment(counterpartMemberIds.get(index), txIds.get(index));
                     } catch (Exception e) {
                         System.out.println("e = " + e.getMessage());
                     } finally {
@@ -163,11 +168,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             CountDownLatch doneLatch = new CountDownLatch(buyUserCount);
             for (int i = 0; i < buyUserCount; i++) {
                 final int index = i;
-                String formattedIndex = String.format("%02d", index);
                 executor.submit(() -> {
                     try {
                         startLatch.await();
-                        paymentService.confirmPayment(mainMemberId, new PaymentTokenDto("TXN_" + formattedIndex, POST_PRICE, postIds.get(index)));
+                        paymentService.confirmPayment(mainMemberId, txIds.get(index));
                     } catch (Exception e) {
                         System.out.println("e = " + e.getMessage());
                     } finally {
@@ -240,11 +244,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
 
             for (int i = 0; i < buyUserCount; i++) {
                 final int index = i;
-                String formattedIndex = String.format("%02d", index);
                 executor.submit(() -> {
                     try {
                         startLatch.await();
-                        paymentService.confirmPayment(mainMemberId, new PaymentTokenDto("TXN_" + formattedIndex, POST_PRICE, postIds.get(index)));
+                        paymentService.confirmPayment(mainMemberId, txIds.get(index));
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         boolean isExpected = e instanceof InvalidInputException && "잔액이 부족합니다.".equals(e.getMessage());
@@ -313,7 +316,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                 executor.submit(() -> {
                     try {
                         startLatch.await();
-                        paymentService.confirmPayment(mainMemberId, new PaymentTokenDto("TXN_11" , POST_PRICE, postIds.get(1))); //동일한 tranSeqNo
+                        paymentService.confirmPayment(mainMemberId, txIds.getFirst()); //동일한 tranSeqNo
                         successCount.incrementAndGet();
                     } catch (Exception e) {
                         boolean isExpected = e instanceof DataIntegrityViolationException
@@ -376,9 +379,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             Long memberAId = mainMemberId;
             Long memberBId = counterpartMemberIds.getFirst();
 
-            initPosts(List.of(memberAId,memberBId));
-            Long postA = postIds.getFirst();
-            Long postB = postIds.getLast();
+            initPosts(List.of(memberAId, memberBId));
+
+            String txA = txIds.getFirst();
+            String txB = txIds.getLast();
 
             ExecutorService executor = Executors.newFixedThreadPool(2);
             CountDownLatch startLatch = new CountDownLatch(1);
@@ -387,7 +391,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             executor.submit(() -> { //A -> B
                 try {
                     startLatch.await();
-                    paymentService.confirmPayment(memberAId, new PaymentTokenDto("TXN_A_TO_B" , POST_PRICE, postB));
+                    paymentService.confirmPayment(memberAId, txB);
                 } catch (Exception e) {
                     System.out.println("e = " + e.getMessage());
                 } finally {
@@ -398,7 +402,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             executor.submit(() -> { // B -> A
                 try {
                     startLatch.await();
-                    paymentService.confirmPayment(memberBId, new PaymentTokenDto("TXN_B_TO_A" , POST_PRICE, postA));
+                    paymentService.confirmPayment(memberBId, txA);
                 } catch (Exception e) {
                     System.out.println("e = " + e.getMessage());
                 } finally {
@@ -442,7 +446,6 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             initCounterpartMembers(buyUserCount);
 
             initPosts(List.of(mainMemberId));
-            Long sharedPostId = postIds.getFirst();
 
             ExecutorService executor = Executors.newFixedThreadPool(buyUserCount);
             CountDownLatch startLatch = new CountDownLatch(1);
@@ -450,11 +453,10 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
 
             for (int i = 0; i < buyUserCount; i++) {
                 final int index = i;
-                String formattedIndex = String.format("%02d", index);
                 executor.submit(() -> {
                     try {
                         startLatch.await();
-                        paymentService.confirmPayment(counterpartMemberIds.get(index), new PaymentTokenDto("TXN_" + formattedIndex, POST_PRICE, sharedPostId));
+                        paymentService.confirmPayment(counterpartMemberIds.get(index), txIds.getFirst());
                     } catch (Exception e) {
                         System.out.println("e = " + e.getMessage());
                     } finally {
@@ -515,7 +517,11 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
                 Member seller = em.find(Member.class, sellerId);
                 Post targetPost = new Post(seller, "제목", "내용", POST_PRICE, ADDRESS);
                 em.persist(targetPost);
-                postIds.add(targetPost.getId());
+
+                UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
+                PaymentToken paymentToken = new PaymentToken(tranSeqNo, targetPost.getId(), sellerId, POST_PRICE, PaymentTokenStatus.PENDING);
+                em.persist(paymentToken);
+                txIds.add(tranSeqNo.toString());
             }
             em.flush();
             em.clear();

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -12,6 +12,7 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -83,11 +84,12 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
         @DisplayName("[동시성] n명이 한명의 게시물 n건 구매시 판매자의 잔액 검증")
         public void confirmPayment_MultiBuyersSingleSeller_Success() throws Exception {
             //given
+            int buyUserCount = 100;
+
             List<Long> sellers = Collections.nCopies(100, mainMemberId);
             initPosts(sellers);
-            initCounterpartMembers();
+            initCounterpartMembers(buyUserCount);
 
-            int buyUserCount = 100;
             ExecutorService executor = Executors.newFixedThreadPool(buyUserCount);
             CountDownLatch startLatch = new CountDownLatch(1);
             CountDownLatch doneLatch = new CountDownLatch(buyUserCount);
@@ -150,11 +152,12 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
         @DisplayName("[동시성] 한명이 n명의 게시물 n건 구매시 구매자의 잔액 검증")
         public void confirmPayment_SingleBuyerMultiSellers_Success() throws Exception {
             //given
-            initCounterpartMembers();
+            int buyUserCount = 100;
+
+            initCounterpartMembers(buyUserCount);
             initPosts(counterpartMemberIds);
             settingMemberBalance();
 
-            int buyUserCount = 100;
             ExecutorService executor = Executors.newFixedThreadPool(buyUserCount);
             CountDownLatch startLatch = new CountDownLatch(1);
             CountDownLatch doneLatch = new CountDownLatch(buyUserCount);
@@ -221,10 +224,11 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
         @DisplayName("[동시성] 잔액 부족 시 1건만 성공하고 나머지는 잔액부족 예외 발생")
         public void confirmPayment_InsufficientBalance_PartialSuccess() throws Exception {
             //given
-            initCounterpartMembers();
+            int buyUserCount = 2;
+
+            initCounterpartMembers(buyUserCount);
             initPosts(counterpartMemberIds);
 
-            int buyUserCount = 2;
             ExecutorService executor = Executors.newFixedThreadPool(buyUserCount);
             CountDownLatch startLatch = new CountDownLatch(1);
             CountDownLatch doneLatch = new CountDownLatch(buyUserCount);
@@ -274,9 +278,81 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
         }
     }
 
-    private void initCounterpartMembers() {
+    @Nested
+    @DisplayName("동일 결제 링크 중복 결제 확인")
+    class SameBuyerWithSamePaymentToken {
+
+        private static final Long BUYER_INITIAL_BALANCE = 500_000L;
+
+        @Test
+        @DisplayName("[멱등성] 같은 거래 번호로 결제 진행시 중복 확인")
+        public void confirmPayment_DuplicateTokenIdempotency_PartialSuccess() throws Exception {
+            //given
+            int buyUserCount = 2;
+
+            settingMemberBalance();
+
+            initCounterpartMembers(buyUserCount);
+            initPosts(counterpartMemberIds);
+
+            ExecutorService executor = Executors.newFixedThreadPool(buyUserCount);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(buyUserCount);
+            AtomicInteger successCount = new AtomicInteger();
+            AtomicInteger failCount = new AtomicInteger();
+            ConcurrentLinkedQueue<Object> unexpectedErrors = new ConcurrentLinkedQueue<>();
+
+            for (int i = 0; i < buyUserCount; i++) {
+                final int index = i;
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        paymentService.confirmPayment(mainMemberId, new PaymentTokenDto("TXN_11" , POST_PRICE, postIds.get(1))); //동일한 tranSeqNo
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        if (!(e instanceof DataIntegrityViolationException)) unexpectedErrors.add(e);
+                        failCount.incrementAndGet();
+                        System.out.println("e = " + e.getMessage());
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+            //when
+            startLatch.countDown(); //동시 실행 시작
+            doneLatch.await(); // 모든 작업 종료 대기
+            executor.shutdown(); //executor 종료
+            //then
+            assertThat(unexpectedErrors).isEmpty();
+            assertThat(successCount.get()).isEqualTo(1);
+            assertThat(failCount.get()).isEqualTo(1);
+
+            Member member = em.find(Member.class, mainMemberId);
+            assertThat(member.getBalance()).isEqualTo(BUYER_INITIAL_BALANCE);
+
+            List<PaymentHistory> paymentHistoryList = em.createQuery("select p from PaymentHistory p order by p.id asc", PaymentHistory.class)
+                    .getResultList();
+
+            assertThat(paymentHistoryList.size()).isEqualTo(2);
+
+            List<Post> soldPosts = em.createQuery("select p from Post p where p.status = :status", Post.class)
+                    .setParameter("status", PostStatus.SOLD)
+                    .getResultList();
+
+            assertThat(soldPosts).hasSize(1);
+        }
+
+        private void settingMemberBalance() {
+            runInTx(() -> {
+                Member member = em.find(Member.class, mainMemberId);
+                member.changeBalance(true, BUYER_INITIAL_BALANCE);
+            });
+        }
+    }
+
+    private void initCounterpartMembers(int userCount) {
         runInTx(() -> {
-            for (int i = 0; i < 100; i++) {
+            for (int i = 0; i < userCount; i++) {
                 Member member = Member.builder()
                         .email("test" + i + "@test.com")
                         .nickName(INITIAL_NAME)

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceConcurrencyTest.java
@@ -115,7 +115,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE + POST_PRICE * buyUserCount);
 
             List<PaymentHistory> paymentHistoryList = em.createQuery("select p from PaymentHistory p where p.type = :type and p.member.id = :toMemberId", PaymentHistory.class)
-                    .setParameter("type", PaymentStatus.DEPOSIT.getMessage())
+                    .setParameter("type", PaymentStatus.DEPOSIT)
                     .setParameter("toMemberId", mainMemberId)
                     .getResultList();
 
@@ -181,7 +181,7 @@ public class PaymentServiceConcurrencyTest extends TestContainerConfig {
             assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE);
 
             List<PaymentHistory> paymentHistoryList = em.createQuery("select p from PaymentHistory p where p.type = :type and p.member.id = :toMemberId", PaymentHistory.class)
-                    .setParameter("type", PaymentStatus.WITHDRAWAL.getMessage())
+                    .setParameter("type", PaymentStatus.WITHDRAWAL)
                     .setParameter("toMemberId", mainMemberId)
                     .getResultList();
 

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
@@ -149,7 +149,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
                     .member(member)
                     .tranSeqNo(dto.tran_seq_no())
                     .changedCash(dto.tran_amt())
-                    .type(PaymentStatus.DEPOSIT)
+                    .type(PaymentStatus.WITHDRAWAL)
                     .balance(member.getBalance())
                     .localDateTime(LocalDateTime.now())
                     .build();

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
@@ -283,11 +283,9 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
             em.flush();
             em.clear();
 
-            String tx = TRAN_SEQ_NO.toString();
-
             initFromMember();
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, TRAN_SEQ_NO))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("이미 진행된 거래입니다.");
         }
@@ -310,10 +308,8 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
             em.flush();
             em.clear();
 
-            String tx = TRAN_SEQ_NO.toString();
-
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, TRAN_SEQ_NO))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("해당 게시글이 존재하지 않습니다.");
         }
@@ -323,10 +319,10 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         public void confirmPayment_SelfTransaction_ThrowsException() {
             //given
             initPost(false);
-            String tx = TRAN_SEQ_NO.toString();
+            initPaymentToken(false);
 
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(toMemberId, tx))
+            assertThatThrownBy(() -> paymentService.confirmPayment(toMemberId, TRAN_SEQ_NO))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("잘못된 접근입니다.");
         }
@@ -339,10 +335,8 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
             initPaymentToken(false);
             initFromMember();
 
-            String tx = TRAN_SEQ_NO.toString();
-
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, TRAN_SEQ_NO))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("이미 판매된 제품입니다.");
         }
@@ -366,10 +360,8 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
 
             initFromMember();
 
-            String tx = TRAN_SEQ_NO.toString();
-
             //when, then 예외 학인
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, TRAN_SEQ_NO))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("잔액이 부족합니다.");
 

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
@@ -376,6 +376,38 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         }
     }
 
+    @Nested
+    @DisplayName("토큰 조회 예외 테스트")
+    class getTokenInfo{
+
+        @Test
+        @DisplayName("토큰이 없으면 예외를 발생한다.")
+        public void getTokenInfo_NotFound_Throws(){
+            //given
+            initPost(false);
+
+            //when, then
+            assertThatThrownBy(() -> paymentService.getTokenInfo(TRAN_SEQ_NO))
+                    .isInstanceOf(InvalidInputException.class)
+                    .hasMessage("잘못된 링크입니다.");
+
+        }
+
+        @Test
+        @DisplayName("이미 거래가 진행된 토큰으로 인한 예외를 발생한다.")
+        public void getTokenInfo_AlreadyCompletedToken_ThrowsException(){
+            //given
+            initPost(false);
+            initPaymentToken(true);
+
+            //when, then
+            assertThatThrownBy(() -> paymentService.getTokenInfo(TRAN_SEQ_NO))
+                    .isInstanceOf(InvalidInputException.class)
+                    .hasMessage("이미 진행된 거래입니다.");
+
+        }
+    }
+
     private void initPost(Boolean isSold) {
         Member member = em.find(Member.class, toMemberId);
         Address address = new Address("서울시", "동작구", "사당동");

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
@@ -232,9 +232,9 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("존재하지 않는 게시물은 거래를 생성 시 예외가 발생한다.")
         public void requestPayment_NonExistentPost_ThrowsException(){
             //given
-            PaymentInitRequestDto dto = new PaymentInitRequestDto(NON_EXISTENT_ID, TRAN_AMT);
+            PaymentInitRequestDto dto = new PaymentInitRequestDto(toMemberId, NON_EXISTENT_ID, TRAN_AMT);
             //when, then
-            assertThatThrownBy(() -> paymentService.requestPayment(dto))
+            assertThatThrownBy(() -> paymentService.requestPayment(toMemberId, dto))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("해당 게시글이 존재하지 않습니다.");
         }
@@ -245,9 +245,9 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
             //given
             initPost(true);
 
-            PaymentInitRequestDto dto = new PaymentInitRequestDto(postId, TRAN_AMT);
+            PaymentInitRequestDto dto = new PaymentInitRequestDto(toMemberId, postId, TRAN_AMT);
             //when, then
-            assertThatThrownBy(() -> paymentService.requestPayment(dto))
+            assertThatThrownBy(() -> paymentService.requestPayment(toMemberId, dto))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("이미 판매된 제품입니다.");
         }

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
@@ -7,9 +7,10 @@ import com.ktcloud.daangn.config.TestContainerConfig;
 import com.ktcloud.daangn.member.entity.Member;
 import com.ktcloud.daangn.payment.dto.PaymentInitRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentRequestDto;
-import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
 import com.ktcloud.daangn.payment.entity.PaymentStatus;
+import com.ktcloud.daangn.payment.entity.PaymentToken;
+import com.ktcloud.daangn.payment.entity.PaymentTokenStatus;
 import com.ktcloud.daangn.post.entity.Post;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,8 +23,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -39,6 +42,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
     private final Long TRAN_AMT = 5000L;
     private static final Long INITIAL_BALANCE = 5000L;
     private static final Long NON_EXISTENT_ID = Long.MAX_VALUE;
+    private final UUID TRAN_SEQ_NO = UuidCreator.getTimeOrderedEpoch();
 
     private Long toMemberId;
     private Long fromMemberId;
@@ -68,7 +72,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("은행으로부터 중복된 거래 코드가 담긴 API 요청에 대한 예외를 발생한다.")
         public void deposit_DuplicateTranSeqNo_ThrowsException(){
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", TRAN_AMT, toMemberId);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, TRAN_AMT, toMemberId);
 
             Member member = em.find(Member.class, dto.memberId());
             PaymentHistory paymentHistory = PaymentHistory.builder()
@@ -93,7 +97,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("은행으로부터 존재하지 않는 memberId가 담긴 API 요청에 대한 예외를 발생한다.")
         public void deposit_NonExistentMember_ThrowsException() {
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", TRAN_AMT, NON_EXISTENT_ID);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, TRAN_AMT, NON_EXISTENT_ID);
             //when, then
             assertThatThrownBy(() -> paymentService.deposit(dto))
                     .isInstanceOf(InvalidInputException.class)
@@ -104,7 +108,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("은행으로부터 입금 금액이 null인 요청에 대한 예외를 발생한다.")
         public void deposit_NullAmount_ThrowsException() {
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", null, toMemberId);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, null, toMemberId);
             //when, then
             assertThatThrownBy(() -> paymentService.deposit(dto))
                     .isInstanceOf(InvalidInputException.class)
@@ -115,7 +119,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("은행으로부터 입금 금액이 음수인 요청에 대한 예외를 발생한다.")
         public void deposit_NegativeAmount_ThrowsException() {
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", -TRAN_AMT, toMemberId);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, -TRAN_AMT, toMemberId);
             //when, then
             assertThatThrownBy(() -> paymentService.deposit(dto))
                     .isInstanceOf(InvalidInputException.class)
@@ -126,7 +130,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("은행으로부터 입금 금액이 0인 요청에 대한 예외를 발생한다.")
         public void deposit_ZeroAmount_ThrowsException() {
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", 0L, toMemberId);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, 0L, toMemberId);
             //when, then
             assertThatThrownBy(() -> paymentService.deposit(dto))
                     .isInstanceOf(InvalidInputException.class)
@@ -142,7 +146,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("은행으로부터 중복된 거래 코드가 담긴 API 요청에 대한 예외를 발생한다.")
         public void withdraw_DuplicateTranSeqNo_ThrowsException() {
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", TRAN_AMT, toMemberId);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, TRAN_AMT, toMemberId);
 
             Member member = em.find(Member.class, dto.memberId());
             PaymentHistory paymentHistory = PaymentHistory.builder()
@@ -167,7 +171,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("은행으로부터 존재하지 않는 memberId가 담긴 API 요청에 대한 예외를 발생한다.")
         public void withdraw_NonExistentMember_ThrowsException() {
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", TRAN_AMT, NON_EXISTENT_ID);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, TRAN_AMT, NON_EXISTENT_ID);
 
             //when, then
             assertThatThrownBy(() -> paymentService.withdraw(dto))
@@ -179,7 +183,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("은행으로부터 출금 금액이 null인 요청에 대한 예외를 발생시킨다.")
         public void withdraw_NullAmount_ThrowsException() {
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", null, toMemberId);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, null, toMemberId);
 
             //when, then
             assertThatThrownBy(() -> paymentService.withdraw(dto))
@@ -191,7 +195,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("은행으로부터 출금 금액이 음수인 요청에 대한 예외를 발생시킨다.")
         public void withdraw_NegativeAmount_ThrowsException() {
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", -TRAN_AMT, toMemberId);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, -TRAN_AMT, toMemberId);
 
             //when, then
             assertThatThrownBy(() -> paymentService.withdraw(dto))
@@ -203,7 +207,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("은행으로부터 출금 금액이 0인 요청에 대한 예외를 발생시킨다.")
         public void withdraw_ZeroAmount_ThrowsException() {
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", 0L, toMemberId);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, 0L, toMemberId);
 
             //when, then
             assertThatThrownBy(() -> paymentService.withdraw(dto))
@@ -215,7 +219,7 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("잔액 부족으로 인해 출금이 불가능할때 예외를 발생시킨다.")
         public void withdraw_InsufficientBalance_ThrowException() {
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", INITIAL_BALANCE+1L, toMemberId);
+            PaymentRequestDto dto = new PaymentRequestDto(TRAN_SEQ_NO, INITIAL_BALANCE+1L, toMemberId);
 
             //when, then
             assertThatThrownBy(() -> paymentService.withdraw(dto))
@@ -262,24 +266,28 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("이미 처리된 거래코드일 경우 예외가 발생한다.")
         public void confirmPayment_DuplicateTranSeqNo_ThrowsException() {
             //given
-            PaymentTokenDto dto = PaymentTokenDto.parse(initUrl(false, TRAN_AMT));
+            initPost(false);
+            initPaymentToken(true);
 
             Member member = em.find(Member.class, toMemberId);
             PaymentHistory paymentHistory = PaymentHistory.builder()
                     .member(member)
-                    .tranSeqNo(dto.tranSeqNo())
-                    .changedCash(dto.amount())
+                    .tranSeqNo(TRAN_SEQ_NO)
+                    .changedCash(TRAN_AMT)
                     .type(PaymentStatus.DEPOSIT)
                     .balance(member.getBalance())
                     .localDateTime(LocalDateTime.now())
                     .build();
+
             em.persist(paymentHistory);
             em.flush();
             em.clear();
 
+            String tx = TRAN_SEQ_NO.toString();
+
             initFromMember();
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("이미 진행된 거래입니다.");
         }
@@ -288,14 +296,24 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("게시물이 존재하지 않을 경우 예외가 발생한다.")
         public void confirmPayment_NonExistentPost_ThrowsException() {
             //given
-            String[] paseUrl = initUrl(false, TRAN_AMT).split("_");
-            String tranSeqNo = paseUrl[0];
-            Long amount = Long.parseLong(paseUrl[1]);
-            PaymentTokenDto dto = new PaymentTokenDto(tranSeqNo, amount, NON_EXISTENT_ID);
             initFromMember();
 
+            PaymentToken paymentToken = PaymentToken.builder()
+                    .tranSeqNo(TRAN_SEQ_NO)
+                    .postId(NON_EXISTENT_ID)
+                    .sellerId(toMemberId)
+                    .amount(TRAN_AMT)
+                    .status(PaymentTokenStatus.PENDING)
+                    .build();
+
+            em.persist(paymentToken);
+            em.flush();
+            em.clear();
+
+            String tx = TRAN_SEQ_NO.toString();
+
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("해당 게시글이 존재하지 않습니다.");
         }
@@ -304,10 +322,11 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("본인의 게시물을 결제 할 수 없다.")
         public void confirmPayment_SelfTransaction_ThrowsException() {
             //given
-            PaymentTokenDto dto = PaymentTokenDto.parse(initUrl(false, TRAN_AMT));
+            initPost(false);
+            String tx = TRAN_SEQ_NO.toString();
 
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(toMemberId, dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(toMemberId, tx))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("잘못된 접근입니다.");
         }
@@ -316,11 +335,14 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("이미 판매완료된 게시물일 경우 예외가 발생한다")
         public void confirmPayment_AlreadySoldPost_ThrowsException() {
             //given
-            PaymentTokenDto dto = PaymentTokenDto.parse(initUrl(true, TRAN_AMT));
+            initPost(true);
+            initPaymentToken(false);
             initFromMember();
 
+            String tx = TRAN_SEQ_NO.toString();
+
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("이미 판매된 제품입니다.");
         }
@@ -329,11 +351,25 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         @DisplayName("구매자의 잔액이 부족할 경우 예외가 발생한다")
         public void confirmPayment_InsufficientBalance_ThrowsException() {
             //given
-            PaymentTokenDto dto = PaymentTokenDto.parse(initUrl(false, INITIAL_BALANCE + 1L));
+            initPost(false);
+
+            PaymentToken paymentToken = PaymentToken.builder()
+                    .tranSeqNo(TRAN_SEQ_NO)
+                    .postId(postId)
+                    .sellerId(toMemberId)
+                    .amount(INITIAL_BALANCE + 1L)
+                    .status(PaymentTokenStatus.PENDING)
+                    .build();
+            em.persist(paymentToken);
+            em.flush();
+            em.clear();
+
             initFromMember();
 
+            String tx = TRAN_SEQ_NO.toString();
+
             //when, then 예외 학인
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("잔액이 부족합니다.");
 
@@ -367,6 +403,21 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         em.clear();
     }
 
+    private void initPaymentToken(Boolean isCompleted) {
+        PaymentToken paymentToken = PaymentToken.builder()
+                .tranSeqNo(TRAN_SEQ_NO)
+                .postId(postId)
+                .sellerId(toMemberId)
+                .amount(TRAN_AMT)
+                .status(PaymentTokenStatus.PENDING)
+                .build();
+        if (isCompleted) paymentToken.markAsCompleted();
+
+        em.persist(paymentToken);
+        em.flush();
+        em.clear();
+    }
+
     public void initFromMember() {
         Address address = new Address("서울시", "동작구", "사당동");
         Member member = Member.builder()
@@ -380,10 +431,5 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
         em.flush();
         fromMemberId = member.getId();
         em.clear();
-    }
-
-    private String initUrl(Boolean isSold, Long tranAmt) {
-        initPost(isSold);
-        return UuidCreator.getTimeOrderedEpoch() + "_" + tranAmt + "_" + postId;
     }
 }

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationExceptionTest.java
@@ -9,6 +9,7 @@ import com.ktcloud.daangn.payment.dto.PaymentInitRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
+import com.ktcloud.daangn.payment.entity.PaymentStatus;
 import com.ktcloud.daangn.post.entity.Post;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -72,6 +75,9 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
                     .member(member)
                     .tranSeqNo(dto.tran_seq_no())
                     .changedCash(dto.tran_amt())
+                    .type(PaymentStatus.DEPOSIT)
+                    .balance(member.getBalance())
+                    .localDateTime(LocalDateTime.now())
                     .build();
             em.persist(paymentHistory);
             em.flush();
@@ -143,6 +149,9 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
                     .member(member)
                     .tranSeqNo(dto.tran_seq_no())
                     .changedCash(dto.tran_amt())
+                    .type(PaymentStatus.DEPOSIT)
+                    .balance(member.getBalance())
+                    .localDateTime(LocalDateTime.now())
                     .build();
             em.persist(paymentHistory);
             em.flush();
@@ -260,6 +269,9 @@ public class PaymentServiceIntegrationExceptionTest extends TestContainerConfig 
                     .member(member)
                     .tranSeqNo(dto.tranSeqNo())
                     .changedCash(dto.amount())
+                    .type(PaymentStatus.DEPOSIT)
+                    .balance(member.getBalance())
+                    .localDateTime(LocalDateTime.now())
                     .build();
             em.persist(paymentHistory);
             em.flush();

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationTest.java
@@ -11,8 +11,9 @@ import com.ktcloud.daangn.member.entity.Member;
 import com.ktcloud.daangn.payment.dto.PaymentInitRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentResponseDto;
-import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
+import com.ktcloud.daangn.payment.entity.PaymentToken;
+import com.ktcloud.daangn.payment.entity.PaymentTokenStatus;
 import com.ktcloud.daangn.post.entity.Post;
 import com.ktcloud.daangn.post.entity.PostStatus;
 import jakarta.persistence.EntityManager;
@@ -25,8 +26,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,8 +73,8 @@ public class PaymentServiceIntegrationTest extends TestContainerConfig {
         @DisplayName("은행으로부터 정상적인 입금 확인 API 요청이 처리된다.")
         public void deposit_ValidRequest_Success(){
             //given
-
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", TRAN_AMT, toMemberId);
+            UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, TRAN_AMT, toMemberId);
             //when
             PaymentResponseDto result = paymentService.deposit(dto);
             //then
@@ -93,7 +94,8 @@ public class PaymentServiceIntegrationTest extends TestContainerConfig {
         @DisplayName("은행으로부터 정상적인 출금 확인 API 요청이 처리된다.")
         public void withdraw_ValidRequest_Success(){
             //given
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", TRAN_AMT, toMemberId);
+            UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, TRAN_AMT, toMemberId);
             //when
             PaymentResponseDto result = paymentService.withdraw(dto);
             //then
@@ -121,27 +123,44 @@ public class PaymentServiceIntegrationTest extends TestContainerConfig {
             //when
             paymentService.requestPayment(toMemberId, dto);
             //then
-            ChatMessage chatMessage = em.createQuery("SELECT c FROM ChatMessage c", ChatMessage.class)
+            ChatMessage chatMessage = em.createQuery("select c from ChatMessage c", ChatMessage.class)
                     .getSingleResult();
             assertThat(chatMessage.getMessage()).contains("결제 링크입니다!");
             assertThat(chatMessage.getMember().getId()).isEqualTo(toMemberId);
+
+            List<PaymentToken> resultList = em.createQuery("select p from PaymentToken p order by p.tranSeqNo asc", PaymentToken.class)
+                    .getResultList();
+            assertThat(resultList).hasSize(1);
         }
     }
-    
+
     @Nested
     @DisplayName("거래 진행 통합 테스트")
     class ConfirmPaymentTest {
-        
+
         @Test
         @DisplayName("생성된 거래가 정상적으로 진행된다.")
         public void confirmPayment_ValidRequest_Success(){
             //given
             initPost();
             initFromMember();
-            String url = UuidCreator.getTimeOrderedEpoch() + "_" + TRAN_AMT + "_" + postId;
-            PaymentTokenDto dto = PaymentTokenDto.parse(url);
+
+            // PaymentToken DB에 직접 저장
+            UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
+            PaymentToken paymentToken = PaymentToken.builder()
+                    .tranSeqNo(tranSeqNo)
+                    .postId(postId)
+                    .sellerId(toMemberId)
+                    .amount(TRAN_AMT)
+                    .status(PaymentTokenStatus.PENDING)
+                    .build();
+            em.persist(paymentToken);
+            em.flush();
+            em.clear();
+
+            String tx = tranSeqNo.toString();
             //when
-            paymentService.confirmPayment(fromMemberId, dto);
+            paymentService.confirmPayment(fromMemberId, tx);
             //then
             Member toMember = em.find(Member.class, toMemberId);
             Member fromMember = em.find(Member.class, fromMemberId);
@@ -151,12 +170,15 @@ public class PaymentServiceIntegrationTest extends TestContainerConfig {
             Post post = em.find(Post.class, postId);
             assertThat(post.getStatus()).isEqualTo(PostStatus.SOLD);
 
-            List<PaymentHistory> paymentHistoryList = em.createQuery("select p from PaymentHistory p order by p.id asc", PaymentHistory.class)
+            List<PaymentHistory> historyList = em.createQuery(
+                            "SELECT p FROM PaymentHistory p ORDER BY p.id ASC", PaymentHistory.class)
                     .getResultList();
-            assertThat(paymentHistoryList.size()).isEqualTo(2);
+            assertThat(historyList).hasSize(2);
+            assertThat(historyList).extracting(PaymentHistory::getTranSeqNo)
+                    .containsOnly(tranSeqNo);
 
-            String tranSeqNo = Arrays.stream(url.split("_")).findFirst().orElse("미존재");
-            assertThat(paymentHistoryList).extracting(PaymentHistory::getTranSeqNo).contains(tranSeqNo);
+            PaymentToken updatedToken = em.find(PaymentToken.class, tranSeqNo);
+            assertThat(updatedToken.getStatus()).isEqualTo(PaymentTokenStatus.COMPLETED);
         }
     }
 

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationTest.java
@@ -158,9 +158,8 @@ public class PaymentServiceIntegrationTest extends TestContainerConfig {
             em.flush();
             em.clear();
 
-            String tx = tranSeqNo.toString();
             //when
-            paymentService.confirmPayment(fromMemberId, tx);
+            paymentService.confirmPayment(fromMemberId, tranSeqNo);
             //then
             Member toMember = em.find(Member.class, toMemberId);
             Member fromMember = em.find(Member.class, fromMemberId);

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationTest.java
@@ -11,6 +11,7 @@ import com.ktcloud.daangn.member.entity.Member;
 import com.ktcloud.daangn.payment.dto.PaymentInitRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentResponseDto;
+import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
 import com.ktcloud.daangn.payment.entity.PaymentToken;
 import com.ktcloud.daangn.payment.entity.PaymentTokenStatus;
@@ -178,6 +179,41 @@ public class PaymentServiceIntegrationTest extends TestContainerConfig {
 
             PaymentToken updatedToken = em.find(PaymentToken.class, tranSeqNo);
             assertThat(updatedToken.getStatus()).isEqualTo(PaymentTokenStatus.COMPLETED);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 조회 정상 테스트")
+    class getTokenInfo{
+
+        @Test
+        @DisplayName("토큰이 존재하면 DTO로 변환해서 리턴한다.")
+        public void getTokenInfo_ValidRequest_Success(){
+            //given
+            //given
+            initPost();
+            initFromMember();
+
+            // PaymentToken DB에 직접 저장
+            UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
+            PaymentToken paymentToken = PaymentToken.builder()
+                    .tranSeqNo(tranSeqNo)
+                    .postId(postId)
+                    .sellerId(toMemberId)
+                    .amount(TRAN_AMT)
+                    .status(PaymentTokenStatus.PENDING)
+                    .build();
+            em.persist(paymentToken);
+            em.flush();
+            em.clear();
+
+            //when
+            PaymentTokenDto dto = paymentService.getTokenInfo(tranSeqNo);
+            //then
+            assertThat(dto).isNotNull();
+            assertThat(dto.tranSeqNo()).isEqualTo(tranSeqNo);
+            assertThat(dto.postId()).isEqualTo(postId);
+            assertThat(dto.amount()).isEqualTo(TRAN_AMT);
         }
     }
 

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceIntegrationTest.java
@@ -1,6 +1,10 @@
 package com.ktcloud.daangn.payment.service;
 
 import com.github.f4b6a3.uuid.UuidCreator;
+import com.ktcloud.daangn.chat.entity.ChatMessage;
+import com.ktcloud.daangn.chat.entity.ChatParticipant;
+import com.ktcloud.daangn.chat.entity.ChatRoom;
+import com.ktcloud.daangn.chat.entity.ChatType;
 import com.ktcloud.daangn.common.valueObject.Address;
 import com.ktcloud.daangn.config.TestContainerConfig;
 import com.ktcloud.daangn.member.entity.Member;
@@ -42,6 +46,7 @@ public class PaymentServiceIntegrationTest extends TestContainerConfig {
     private Long toMemberId;
     private Long fromMemberId;
     private Long postId;
+    private Long roomId;
 
     @BeforeEach
     public void initToMember(){
@@ -109,15 +114,17 @@ public class PaymentServiceIntegrationTest extends TestContainerConfig {
         public void requestPayment_ValidRequest_Success(){
             //given
             initPost();
-            PaymentInitRequestDto dto = new PaymentInitRequestDto(postId, TRAN_AMT);
+            initFromMember();
+            initChatRoom();
+
+            PaymentInitRequestDto dto = new PaymentInitRequestDto(roomId, postId, TRAN_AMT);
             //when
-            String result = paymentService.requestPayment(dto);
+            paymentService.requestPayment(toMemberId, dto);
             //then
-            String[] results = result.split("_");
-            assertThat(results.length).isEqualTo(3);
-            assertThat(results[0]).isNotBlank();
-            assertThat(results[1]).isEqualTo(TRAN_AMT.toString());
-            assertThat(results[2]).isEqualTo(postId.toString());
+            ChatMessage chatMessage = em.createQuery("SELECT c FROM ChatMessage c", ChatMessage.class)
+                    .getSingleResult();
+            assertThat(chatMessage.getMessage()).contains("결제 링크입니다!");
+            assertThat(chatMessage.getMember().getId()).isEqualTo(toMemberId);
         }
     }
     
@@ -175,6 +182,21 @@ public class PaymentServiceIntegrationTest extends TestContainerConfig {
         em.persist(targetPost);
         em.flush();
         postId = targetPost.getId();
+        em.clear();
+    }
+
+    private void initChatRoom() {
+        Member seller = em.find(Member.class, toMemberId);
+        Member buyer = em.find(Member.class, fromMemberId);
+
+        ChatRoom chatRoom = ChatRoom.createRoom(postId, ChatType.PRODUCT);
+        em.persist(chatRoom);
+
+        em.persist(ChatParticipant.createParticipant(chatRoom, seller));
+        em.persist(ChatParticipant.createParticipant(chatRoom, buyer));
+
+        em.flush();
+        roomId = chatRoom.getId();
         em.clear();
     }
 }

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
@@ -341,7 +341,7 @@ public class PaymentServiceUnitExceptionTest {
             //given
             UUID tx = UuidCreator.getTimeOrderedEpoch();
 
-            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.empty());
+            given(paymentTokenRepository.getTokenWithLock(tx)).willReturn(Optional.empty());
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(1L, tx))
                     .isInstanceOf(InvalidInputException.class)
@@ -355,7 +355,7 @@ public class PaymentServiceUnitExceptionTest {
             UUID tx = UuidCreator.getTimeOrderedEpoch();
             PaymentToken completedToken = new PaymentToken(tx, 1L, 1L, 5000L, PaymentTokenStatus.COMPLETED);
 
-            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(completedToken));
+            given(paymentTokenRepository.getTokenWithLock(tx)).willReturn(Optional.of(completedToken));
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(1L, tx))
                     .isInstanceOf(InvalidInputException.class)
@@ -370,7 +370,7 @@ public class PaymentServiceUnitExceptionTest {
             UUID tx = UuidCreator.getTimeOrderedEpoch();
             PaymentToken findToken = new PaymentToken(tx, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(findToken));
+            given(paymentTokenRepository.getTokenWithLock(tx)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willThrow(new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(1L, tx))
@@ -400,7 +400,7 @@ public class PaymentServiceUnitExceptionTest {
             UUID tx = UuidCreator.getTimeOrderedEpoch();
             PaymentToken findToken = new PaymentToken(tx, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(findToken));
+            given(paymentTokenRepository.getTokenWithLock(tx)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(fromMember.getId(), tx))
@@ -432,7 +432,7 @@ public class PaymentServiceUnitExceptionTest {
             UUID tx = UuidCreator.getTimeOrderedEpoch();
             PaymentToken findToken = new PaymentToken(tx, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(findToken));
+            given(paymentTokenRepository.getTokenWithLock(tx)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
@@ -472,7 +472,7 @@ public class PaymentServiceUnitExceptionTest {
             UUID tx = UuidCreator.getTimeOrderedEpoch();
             PaymentToken findToken = new PaymentToken(tx, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(findToken));
+            given(paymentTokenRepository.getTokenWithLock(tx)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             given(memberService.getByIdOrThrowWithLock(fromMemberId)).willReturn(fromMember);
             given(memberService.getByIdOrThrowWithLock(toMemberId)).willReturn(toMember);
@@ -480,6 +480,44 @@ public class PaymentServiceUnitExceptionTest {
             assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("잔액이 부족합니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 조회 예외 테스트")
+    class getTokenInfo{
+
+        @Test
+        @DisplayName("토큰이 없으면 예외를 발생한다.")
+        public void getTokenInfo_NotFound_Throws(){
+            //given
+            UUID tx = UuidCreator.getTimeOrderedEpoch();
+
+            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.empty());
+            //when, then
+            assertThatThrownBy(() -> paymentService.getTokenInfo(tx))
+                    .isInstanceOf(InvalidInputException.class)
+                    .hasMessage("잘못된 링크입니다.");
+
+        }
+
+        @Test
+        @DisplayName("이미 거래가 진행된 토큰으로 인한 예외를 발생한다.")
+        public void getTokenInfo_AlreadyCompletedToken_ThrowsException(){
+            //given
+            long postId = 1L;
+            long toMemberId = 1L;
+            long tranAmt = 5000L;
+
+            UUID tx = UuidCreator.getTimeOrderedEpoch();
+            PaymentToken paymentToken = new PaymentToken(tx,postId,toMemberId,tranAmt, PaymentTokenStatus.COMPLETED);
+
+            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(paymentToken));
+            //when, then
+            assertThatThrownBy(() -> paymentService.getTokenInfo(tx))
+                    .isInstanceOf(InvalidInputException.class)
+                    .hasMessage("이미 진행된 거래입니다.");
+
         }
     }
 }

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
@@ -449,10 +449,10 @@ public class PaymentServiceUnitExceptionTest {
 
             given(paymentRepository.existsByTranSeqNo(dto.tranSeqNo())).willReturn(false);
             given(postService.getPostOrThrow(postId)).willReturn(targetPost);
-            given(memberService.getByIdOrThrow(fromMemberId)).willReturn(fromMember);
-            given(memberService.getByIdOrThrow(toMemberId)).willReturn(toMember);
+            given(memberService.getByIdOrThrowWithLock(fromMemberId)).willReturn(fromMember);
+            given(memberService.getByIdOrThrowWithLock(toMemberId)).willReturn(toMember);
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMember.getId(), dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, dto))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("잔액이 부족합니다.");
         }

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
@@ -277,12 +277,14 @@ public class PaymentServiceUnitExceptionTest {
         @DisplayName("존재하지 않는 게시물은 거래를 생성 시 예외가 발생한다.")
         public void requestPayment_NonExistentPost_ThrowsException(){
             //given
-            Long tranAmt = 5000L, postId = 1L;
-            PaymentInitRequestDto dto = new PaymentInitRequestDto(postId, tranAmt);
+            Long tranAmt = 5000L;
+            Long postId = 1L;
+            Long toMemberId = 1L;
+            PaymentInitRequestDto dto = new PaymentInitRequestDto(toMemberId, postId, tranAmt);
 
             given(postService.getPostOrThrow(dto.postId())).willThrow(new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
             //when, then
-            assertThatThrownBy(() -> paymentService.requestPayment(dto))
+            assertThatThrownBy(() -> paymentService.requestPayment(toMemberId, dto))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("해당 게시글이 존재하지 않습니다.");
         }
@@ -292,9 +294,11 @@ public class PaymentServiceUnitExceptionTest {
         public void requestPayment_AlreadySoldPost_ThrowsException() {
             //given
             Address address = new Address("서울", "강남", "역삼");
-            Long tranAmt = 5000L, postId = 1L;
+            Long tranAmt = 5000L;
+            Long postId = 1L;
+            Long toMemberId = 1L;
 
-            PaymentInitRequestDto dto = new PaymentInitRequestDto(postId, tranAmt);
+            PaymentInitRequestDto dto = new PaymentInitRequestDto(toMemberId,postId, tranAmt);
 
             Member toMember = Member.builder()
                     .id(2L)
@@ -310,7 +314,7 @@ public class PaymentServiceUnitExceptionTest {
 
             given(postService.getPostOrThrow(postId)).willReturn(targetPost);
             //when, then
-            assertThatThrownBy(() -> paymentService.requestPayment(dto))
+            assertThatThrownBy(() -> paymentService.requestPayment(toMemberId,dto))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("이미 판매된 제품입니다.");
         }

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
@@ -7,8 +7,10 @@ import com.ktcloud.daangn.member.entity.Member;
 import com.ktcloud.daangn.member.service.MemberService;
 import com.ktcloud.daangn.payment.dto.PaymentInitRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentRequestDto;
-import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
+import com.ktcloud.daangn.payment.entity.PaymentToken;
+import com.ktcloud.daangn.payment.entity.PaymentTokenStatus;
 import com.ktcloud.daangn.payment.repository.PaymentRepository;
+import com.ktcloud.daangn.payment.repository.PaymentTokenRepository;
 import com.ktcloud.daangn.post.entity.Post;
 import com.ktcloud.daangn.post.entity.PostStatus;
 import com.ktcloud.daangn.post.service.PostService;
@@ -22,6 +24,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
@@ -34,6 +39,8 @@ public class PaymentServiceUnitExceptionTest {
     private PaymentRepository paymentRepository;
     @Mock
     private PostService postService;
+    @Mock
+    private PaymentTokenRepository paymentTokenRepository;
 
     @InjectMocks
     private PaymentServiceImpl paymentService;
@@ -42,12 +49,14 @@ public class PaymentServiceUnitExceptionTest {
     @DisplayName("입금 예외 테스트")
     class DepositExceptionTest {
 
+        UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
+
         @Test
         @DisplayName("은행으로부터 중복된 거래 코드가 담긴 API 요청에 대한 예외를 발생한다.")
         public void deposit_DuplicateTranSeqNo_ThrowsException() {
             //given
             Long tran_amt = 5000L;
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 1L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 1L);
 
             given(paymentRepository.existsByTranSeqNo(dto.tran_seq_no())).willReturn(true);
             //when, then
@@ -61,7 +70,7 @@ public class PaymentServiceUnitExceptionTest {
         public void deposit_NonExistentMember_ThrowsException() {
             //given
             Long tran_amt = 5000L;
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 99L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 99L);
 
             given(paymentRepository.existsByTranSeqNo(dto.tran_seq_no())).willReturn(false);
             given(memberService.getByIdOrThrow(dto.memberId())).willThrow(new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다."));
@@ -78,7 +87,7 @@ public class PaymentServiceUnitExceptionTest {
             //given
             Long tran_amt = null;
 
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 1L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 1L);
             Member findMember = Member.builder()
                     .id(1L)
                     .email("test@test.com")
@@ -101,7 +110,7 @@ public class PaymentServiceUnitExceptionTest {
             //given
             Long tran_amt = -5000L;
 
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 1L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 1L);
             Member findMember = Member.builder()
                     .id(1L)
                     .email("test@test.com")
@@ -124,7 +133,7 @@ public class PaymentServiceUnitExceptionTest {
             //given
             Long tran_amt = 0L;
 
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 1L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 1L);
             Member findMember = Member.builder()
                     .id(1L)
                     .email("test@test.com")
@@ -146,12 +155,14 @@ public class PaymentServiceUnitExceptionTest {
     @DisplayName("출금 예외 테스트")
     class WithdrawExceptionTest {
 
+        UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
+
         @Test
         @DisplayName("은행으로부터 중복된 거래 코드가 담긴 API 요청에 대한 예외를 발생한다.")
         public void withdraw_DuplicateTranSeqNo_ThrowsException() {
             //given
             Long tran_amt = 5000L;
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 1L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 1L);
 
             given(paymentRepository.existsByTranSeqNo(dto.tran_seq_no())).willReturn(true);
             //when, then
@@ -165,7 +176,7 @@ public class PaymentServiceUnitExceptionTest {
         public void withdraw_NonExistentMember_ThrowsException() {
             //given
             Long tran_amt = 5000L;
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 99L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 99L);
 
             given(paymentRepository.existsByTranSeqNo(dto.tran_seq_no())).willReturn(false);
             given(memberService.getByIdOrThrow(dto.memberId())).willThrow(new InvalidInputException(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다."));
@@ -182,7 +193,7 @@ public class PaymentServiceUnitExceptionTest {
 
             Long tran_amt = null;
 
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 99L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 99L);
             Member findMember = Member.builder()
                     .id(1L)
                     .email("test@test.com")
@@ -205,7 +216,7 @@ public class PaymentServiceUnitExceptionTest {
             //given
             Long tran_amt = -5000L;
 
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 99L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 99L);
             Member findMember = Member.builder()
                     .id(1L)
                     .email("test@test.com")
@@ -228,7 +239,7 @@ public class PaymentServiceUnitExceptionTest {
             //given
             Long tran_amt = 0L;
 
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 99L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 99L);
             Member findMember = Member.builder()
                     .id(1L)
                     .email("test@test.com")
@@ -251,7 +262,7 @@ public class PaymentServiceUnitExceptionTest {
             //given
             Long tran_amt = 5000L;
 
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tran_amt, 99L);
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tran_amt, 99L);
             Member findMember = Member.builder()
                     .id(1L)
                     .email("test@test.com")
@@ -325,17 +336,30 @@ public class PaymentServiceUnitExceptionTest {
     class confirmPaymentExceptionTest {
 
         @Test
+        @DisplayName("존재하지 않는 거래 코드일 경우 예외가 발생한다.")
+        public void confirmPayment_InvalidToken_ThrowsException() {
+            //given
+            UUID token = UuidCreator.getTimeOrderedEpoch();
+            String tx = token.toString();
+
+            given(paymentTokenRepository.getToken(token)).willReturn(Optional.empty());
+            //when, then
+            assertThatThrownBy(() -> paymentService.confirmPayment(1L, tx))
+                    .isInstanceOf(InvalidInputException.class)
+                    .hasMessage("잘못된 접근입니다.");
+        }
+
+        @Test
         @DisplayName("이미 처리된 거래코드일 경우 예외가 발생한다.")
         public void confirmPayment_DuplicateTranSeqNo_ThrowsException() {
             //given
-            Long tranAmt = 5000L;
-            Long postId = 1L;
-            String url = UuidCreator.getTimeOrderedEpoch() + "_" + tranAmt + "_" + postId;
-            PaymentTokenDto dto = PaymentTokenDto.parse(url);
+            UUID token = UuidCreator.getTimeOrderedEpoch();
+            String tx = token.toString();
+            PaymentToken completedToken = new PaymentToken(token, 1L, 1L, 5000L, PaymentTokenStatus.COMPLETED);
 
-            given(paymentRepository.existsByTranSeqNo(dto.tranSeqNo())).willReturn(true);
+            given(paymentTokenRepository.getToken(token)).willReturn(Optional.of(completedToken));
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(1L, dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(1L, tx))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("이미 진행된 거래입니다.");
         }
@@ -344,15 +368,15 @@ public class PaymentServiceUnitExceptionTest {
         @DisplayName("게시물이 존재하지 않을 경우 예외가 발생한다.")
         public void confirmPayment_NonExistentPost_ThrowsException() {
             //given
-            Long tranAmt = 5000L;
             Long postId = 1L;
-            String url = UuidCreator.getTimeOrderedEpoch() + "_" + tranAmt + "_" + postId;
-            PaymentTokenDto dto = PaymentTokenDto.parse(url);
+            UUID token = UuidCreator.getTimeOrderedEpoch();
+            String tx = token.toString();
+            PaymentToken findToken = new PaymentToken(token, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentRepository.existsByTranSeqNo(dto.tranSeqNo())).willReturn(false);
+            given(paymentTokenRepository.getToken(token)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willThrow(new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(1L, dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(1L, tx))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("해당 게시글이 존재하지 않습니다.");
         }
@@ -376,13 +400,14 @@ public class PaymentServiceUnitExceptionTest {
             Post targetPost = new Post(fromMember, "제목", "내용", tranAmt, address);
             ReflectionTestUtils.setField(targetPost, "id", postId);
 
-            String url = UuidCreator.getTimeOrderedEpoch() + "_" + tranAmt + "_" + postId;
-            PaymentTokenDto dto = PaymentTokenDto.parse(url);
+            UUID token = UuidCreator.getTimeOrderedEpoch();
+            String tx = token.toString();
+            PaymentToken findToken = new PaymentToken(token, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentRepository.existsByTranSeqNo(dto.tranSeqNo())).willReturn(false);
+            given(paymentTokenRepository.getToken(token)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMember.getId(), dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMember.getId(), tx))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("잘못된 접근입니다.");
         }
@@ -408,13 +433,14 @@ public class PaymentServiceUnitExceptionTest {
             ReflectionTestUtils.setField(targetPost, "id", postId);
             ReflectionTestUtils.setField(targetPost, "status", PostStatus.SOLD);
 
-            String url = UuidCreator.getTimeOrderedEpoch() + "_" + tranAmt + "_" + postId;
-            PaymentTokenDto dto = PaymentTokenDto.parse(url);
+            UUID token = UuidCreator.getTimeOrderedEpoch();
+            String tx = token.toString();
+            PaymentToken findToken = new PaymentToken(token, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentRepository.existsByTranSeqNo(dto.tranSeqNo())).willReturn(false);
+            given(paymentTokenRepository.getToken(token)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("이미 판매된 제품입니다.");
         }
@@ -448,15 +474,16 @@ public class PaymentServiceUnitExceptionTest {
             Post targetPost = new Post(toMember, "제목", "내용", tranAmt, address);
             ReflectionTestUtils.setField(targetPost, "id", postId);
 
-            String url = UuidCreator.getTimeOrderedEpoch() + "_" + tranAmt + "_" + postId;
-            PaymentTokenDto dto = PaymentTokenDto.parse(url);
+            UUID token = UuidCreator.getTimeOrderedEpoch();
+            String tx = token.toString();
+            PaymentToken findToken = new PaymentToken(token, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentRepository.existsByTranSeqNo(dto.tranSeqNo())).willReturn(false);
+            given(paymentTokenRepository.getToken(token)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             given(memberService.getByIdOrThrowWithLock(fromMemberId)).willReturn(fromMember);
             given(memberService.getByIdOrThrowWithLock(toMemberId)).willReturn(toMember);
             //when, then
-            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, dto))
+            assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
                     .isInstanceOf(InvalidInputException.class)
                     .hasMessage("잔액이 부족합니다.");
         }

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
@@ -339,10 +339,9 @@ public class PaymentServiceUnitExceptionTest {
         @DisplayName("존재하지 않는 거래 코드일 경우 예외가 발생한다.")
         public void confirmPayment_InvalidToken_ThrowsException() {
             //given
-            UUID token = UuidCreator.getTimeOrderedEpoch();
-            String tx = token.toString();
+            UUID tx = UuidCreator.getTimeOrderedEpoch();
 
-            given(paymentTokenRepository.getToken(token)).willReturn(Optional.empty());
+            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.empty());
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(1L, tx))
                     .isInstanceOf(InvalidInputException.class)
@@ -353,11 +352,10 @@ public class PaymentServiceUnitExceptionTest {
         @DisplayName("이미 처리된 거래코드일 경우 예외가 발생한다.")
         public void confirmPayment_DuplicateTranSeqNo_ThrowsException() {
             //given
-            UUID token = UuidCreator.getTimeOrderedEpoch();
-            String tx = token.toString();
-            PaymentToken completedToken = new PaymentToken(token, 1L, 1L, 5000L, PaymentTokenStatus.COMPLETED);
+            UUID tx = UuidCreator.getTimeOrderedEpoch();
+            PaymentToken completedToken = new PaymentToken(tx, 1L, 1L, 5000L, PaymentTokenStatus.COMPLETED);
 
-            given(paymentTokenRepository.getToken(token)).willReturn(Optional.of(completedToken));
+            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(completedToken));
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(1L, tx))
                     .isInstanceOf(InvalidInputException.class)
@@ -369,11 +367,10 @@ public class PaymentServiceUnitExceptionTest {
         public void confirmPayment_NonExistentPost_ThrowsException() {
             //given
             Long postId = 1L;
-            UUID token = UuidCreator.getTimeOrderedEpoch();
-            String tx = token.toString();
-            PaymentToken findToken = new PaymentToken(token, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
+            UUID tx = UuidCreator.getTimeOrderedEpoch();
+            PaymentToken findToken = new PaymentToken(tx, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentTokenRepository.getToken(token)).willReturn(Optional.of(findToken));
+            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willThrow(new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(1L, tx))
@@ -400,11 +397,10 @@ public class PaymentServiceUnitExceptionTest {
             Post targetPost = new Post(fromMember, "제목", "내용", tranAmt, address);
             ReflectionTestUtils.setField(targetPost, "id", postId);
 
-            UUID token = UuidCreator.getTimeOrderedEpoch();
-            String tx = token.toString();
-            PaymentToken findToken = new PaymentToken(token, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
+            UUID tx = UuidCreator.getTimeOrderedEpoch();
+            PaymentToken findToken = new PaymentToken(tx, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentTokenRepository.getToken(token)).willReturn(Optional.of(findToken));
+            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(fromMember.getId(), tx))
@@ -433,11 +429,10 @@ public class PaymentServiceUnitExceptionTest {
             ReflectionTestUtils.setField(targetPost, "id", postId);
             ReflectionTestUtils.setField(targetPost, "status", PostStatus.SOLD);
 
-            UUID token = UuidCreator.getTimeOrderedEpoch();
-            String tx = token.toString();
-            PaymentToken findToken = new PaymentToken(token, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
+            UUID tx = UuidCreator.getTimeOrderedEpoch();
+            PaymentToken findToken = new PaymentToken(tx, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentTokenRepository.getToken(token)).willReturn(Optional.of(findToken));
+            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, tx))
@@ -474,11 +469,10 @@ public class PaymentServiceUnitExceptionTest {
             Post targetPost = new Post(toMember, "제목", "내용", tranAmt, address);
             ReflectionTestUtils.setField(targetPost, "id", postId);
 
-            UUID token = UuidCreator.getTimeOrderedEpoch();
-            String tx = token.toString();
-            PaymentToken findToken = new PaymentToken(token, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
+            UUID tx = UuidCreator.getTimeOrderedEpoch();
+            PaymentToken findToken = new PaymentToken(tx, 1L, 1L, 5000L, PaymentTokenStatus.PENDING);
 
-            given(paymentTokenRepository.getToken(token)).willReturn(Optional.of(findToken));
+            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(findToken));
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             given(memberService.getByIdOrThrowWithLock(fromMemberId)).willReturn(fromMember);
             given(memberService.getByIdOrThrowWithLock(toMemberId)).willReturn(toMember);

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitExceptionTest.java
@@ -346,7 +346,7 @@ public class PaymentServiceUnitExceptionTest {
             PaymentTokenDto dto = PaymentTokenDto.parse(url);
 
             given(paymentRepository.existsByTranSeqNo(dto.tranSeqNo())).willReturn(false);
-            given(postService.getPostOrThrow(postId)).willThrow(new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+            given(postService.getPostOrThrowWithLock(postId)).willThrow(new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(1L, dto))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -376,7 +376,7 @@ public class PaymentServiceUnitExceptionTest {
             PaymentTokenDto dto = PaymentTokenDto.parse(url);
 
             given(paymentRepository.existsByTranSeqNo(dto.tranSeqNo())).willReturn(false);
-            given(postService.getPostOrThrow(postId)).willReturn(targetPost);
+            given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(fromMember.getId(), dto))
                     .isInstanceOf(InvalidInputException.class)
@@ -408,7 +408,7 @@ public class PaymentServiceUnitExceptionTest {
             PaymentTokenDto dto = PaymentTokenDto.parse(url);
 
             given(paymentRepository.existsByTranSeqNo(dto.tranSeqNo())).willReturn(false);
-            given(postService.getPostOrThrow(postId)).willReturn(targetPost);
+            given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             //when, then
             assertThatThrownBy(() -> paymentService.confirmPayment(fromMemberId, dto))
                     .isInstanceOf(InvalidInputException.class)
@@ -448,7 +448,7 @@ public class PaymentServiceUnitExceptionTest {
             PaymentTokenDto dto = PaymentTokenDto.parse(url);
 
             given(paymentRepository.existsByTranSeqNo(dto.tranSeqNo())).willReturn(false);
-            given(postService.getPostOrThrow(postId)).willReturn(targetPost);
+            given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             given(memberService.getByIdOrThrowWithLock(fromMemberId)).willReturn(fromMember);
             given(memberService.getByIdOrThrowWithLock(toMemberId)).willReturn(toMember);
             //when, then

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
@@ -168,8 +168,8 @@ class PaymentServiceUnitTest {
             String url = UuidCreator.getTimeOrderedEpoch() + "_" + tranAmt + "_" + targetPost.getId();
             PaymentTokenDto dto = PaymentTokenDto.parse(url);
 
-            given(memberService.getByIdOrThrow(fromMemberId)).willReturn(fromMember);
-            given(memberService.getByIdOrThrow(toMemberId)).willReturn(toMember);
+            given(memberService.getByIdOrThrowWithLock(fromMemberId)).willReturn(fromMember);
+            given(memberService.getByIdOrThrowWithLock(toMemberId)).willReturn(toMember);
             given(postService.getPostOrThrow(postId)).willReturn(targetPost);
 
             //when

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
@@ -170,7 +170,7 @@ class PaymentServiceUnitTest {
 
             given(memberService.getByIdOrThrowWithLock(fromMemberId)).willReturn(fromMember);
             given(memberService.getByIdOrThrowWithLock(toMemberId)).willReturn(toMember);
-            given(postService.getPostOrThrow(postId)).willReturn(targetPost);
+            given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
 
             //when
             PaymentResponseDto result = paymentService.confirmPayment(fromMember.getId(), dto);

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
@@ -9,6 +9,7 @@ import com.ktcloud.daangn.member.service.MemberService;
 import com.ktcloud.daangn.payment.dto.PaymentInitRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentResponseDto;
+import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
 import com.ktcloud.daangn.payment.entity.PaymentToken;
 import com.ktcloud.daangn.payment.entity.PaymentTokenStatus;
@@ -185,7 +186,7 @@ class PaymentServiceUnitTest {
             given(memberService.getByIdOrThrowWithLock(fromMemberId)).willReturn(fromMember);
             given(memberService.getByIdOrThrowWithLock(toMemberId)).willReturn(toMember);
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
-            given(paymentTokenRepository.getToken(tranSeqNo)).willReturn(Optional.of(paymentToken));
+            given(paymentTokenRepository.getTokenWithLock(tranSeqNo)).willReturn(Optional.of(paymentToken));
             //when
             PaymentResponseDto result = paymentService.confirmPayment(fromMember.getId(), tranSeqNo);
             //then
@@ -197,6 +198,32 @@ class PaymentServiceUnitTest {
             assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE + tranAmt);
             assertThat(targetPost.getStatus()).isEqualTo(PostStatus.SOLD);
             assertThat(paymentToken.getStatus()).isEqualTo(PaymentTokenStatus.COMPLETED);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 조회 정상 테스트")
+    class getTokenInfo{
+
+        @Test
+        @DisplayName("토큰이 존재하면 DTO로 변환해서 리턴한다.")
+        public void getTokenInfo_ValidRequest_Success(){
+            //given
+            long postId = 1L;
+            long toMemberId = 1L;
+            long tranAmt = 5000L;
+
+            UUID tx = UuidCreator.getTimeOrderedEpoch();
+            PaymentToken paymentToken = new PaymentToken(tx,postId,toMemberId,tranAmt, PaymentTokenStatus.PENDING);
+
+            given(paymentTokenRepository.getToken(tx)).willReturn(Optional.of(paymentToken));
+            //when
+            PaymentTokenDto dto = paymentService.getTokenInfo(tx);
+            //then
+            assertThat(dto).isNotNull();
+            assertThat(dto.tranSeqNo()).isEqualTo(tx);
+            assertThat(dto.postId()).isEqualTo(postId);
+            assertThat(dto.amount()).isEqualTo(tranAmt);
         }
     }
 }

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
@@ -9,9 +9,11 @@ import com.ktcloud.daangn.member.service.MemberService;
 import com.ktcloud.daangn.payment.dto.PaymentInitRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentRequestDto;
 import com.ktcloud.daangn.payment.dto.PaymentResponseDto;
-import com.ktcloud.daangn.payment.dto.PaymentTokenDto;
 import com.ktcloud.daangn.payment.entity.PaymentHistory;
+import com.ktcloud.daangn.payment.entity.PaymentToken;
+import com.ktcloud.daangn.payment.entity.PaymentTokenStatus;
 import com.ktcloud.daangn.payment.repository.PaymentRepository;
+import com.ktcloud.daangn.payment.repository.PaymentTokenRepository;
 import com.ktcloud.daangn.post.entity.Post;
 import com.ktcloud.daangn.post.entity.PostStatus;
 import com.ktcloud.daangn.post.service.PostService;
@@ -24,10 +26,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +41,7 @@ class PaymentServiceUnitTest {
     @Mock private PaymentRepository paymentRepository;
     @Mock private PostService postService;
     @Mock private ChatMessageService chatMessageService;
+    @Mock private PaymentTokenRepository paymentTokenRepository;
 
     @InjectMocks private PaymentServiceImpl paymentService;
 
@@ -51,7 +56,8 @@ class PaymentServiceUnitTest {
         public void deposit_ValidRequest_Success(){
             //given
             Long tranAmt = 5000L;
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tranAmt, 1L);
+            UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tranAmt, 1L);
             Member findMember = Member.builder()
                     .id(1L)
                     .email("test@test.com")
@@ -80,7 +86,8 @@ class PaymentServiceUnitTest {
         public void withdraw_ValidRequest_Success(){
             //given
             Long tranAmt = 5000L;
-            PaymentRequestDto dto = new PaymentRequestDto("tx123123123asd", tranAmt, 1L);
+            UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
+            PaymentRequestDto dto = new PaymentRequestDto(tranSeqNo, tranAmt, 1L);
             Member findMember = Member.builder()
                     .id(1L)
                     .email("test@test.com")
@@ -130,10 +137,12 @@ class PaymentServiceUnitTest {
             given(postService.getPostOrThrow(postId)).willReturn(targetPost);
             given(chatMessageService.create(eq(roomId), eq(toMemberId), contains("결제 링크입니다!")))
                     .willReturn(mock(ChatMessageResponseDto.class));
+            ReflectionTestUtils.setField(paymentService, "paymentLinkBaseUrl", "http://localhost:8080");
             //when
             paymentService.requestPayment(toMemberId, dto);
             // then
-            then(chatMessageService).should(times(1)).create(eq(roomId), eq(toMemberId), contains("결제 링크입니다!"));
+            verify(chatMessageService).create(eq(roomId), eq(toMemberId), contains("결제 링크입니다!"));
+            verify(paymentTokenRepository).save(any(PaymentToken.class));
         }
     }
 
@@ -170,15 +179,16 @@ class PaymentServiceUnitTest {
             Post targetPost = new Post(toMember, "제목", "내용", tranAmt, address);
             ReflectionTestUtils.setField(targetPost, "id", postId);
 
-            String url = UuidCreator.getTimeOrderedEpoch() + "_" + tranAmt + "_" + targetPost.getId();
-            PaymentTokenDto dto = PaymentTokenDto.parse(url);
+            UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
+            String tx = tranSeqNo.toString();
 
+            PaymentToken paymentToken = new PaymentToken(tranSeqNo,postId,toMemberId,tranAmt, PaymentTokenStatus.PENDING);
             given(memberService.getByIdOrThrowWithLock(fromMemberId)).willReturn(fromMember);
             given(memberService.getByIdOrThrowWithLock(toMemberId)).willReturn(toMember);
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
-
+            given(paymentTokenRepository.getToken(tranSeqNo)).willReturn(Optional.of(paymentToken));
             //when
-            PaymentResponseDto result = paymentService.confirmPayment(fromMember.getId(), dto);
+            PaymentResponseDto result = paymentService.confirmPayment(fromMember.getId(), tx);
             //then
             verify(paymentRepository, times(2)).save(any(PaymentHistory.class));
             assertThat(result.balance()).isEqualTo(fromMember.getBalance());
@@ -187,6 +197,7 @@ class PaymentServiceUnitTest {
 
             assertThat(toMember.getBalance()).isEqualTo(INITIAL_BALANCE + tranAmt);
             assertThat(targetPost.getStatus()).isEqualTo(PostStatus.SOLD);
+            assertThat(paymentToken.getStatus()).isEqualTo(PaymentTokenStatus.COMPLETED);
         }
     }
 }

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
@@ -1,6 +1,8 @@
 package com.ktcloud.daangn.payment.service;
 
 import com.github.f4b6a3.uuid.UuidCreator;
+import com.ktcloud.daangn.chat.dto.ChatMessageResponseDto;
+import com.ktcloud.daangn.chat.service.ChatMessageService;
 import com.ktcloud.daangn.common.valueObject.Address;
 import com.ktcloud.daangn.member.entity.Member;
 import com.ktcloud.daangn.member.service.MemberService;
@@ -23,10 +25,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentServiceUnitTest {
@@ -34,6 +36,7 @@ class PaymentServiceUnitTest {
     @Mock private MemberService memberService;
     @Mock private PaymentRepository paymentRepository;
     @Mock private PostService postService;
+    @Mock private ChatMessageService chatMessageService;
 
     @InjectMocks private PaymentServiceImpl paymentService;
 
@@ -106,12 +109,15 @@ class PaymentServiceUnitTest {
         public void requestPayment_ValidRequest_Success(){
             //given
             Address address = new Address("서울", "강남", "역삼");
-            Long tranAmt = 5000L, postId = 1L;
+            Long tranAmt = 5000L;
+            Long postId = 1L;
+            Long roomId = 1L;
+            Long toMemberId = 1L;
 
-            PaymentInitRequestDto dto = new PaymentInitRequestDto(postId, tranAmt);
+            PaymentInitRequestDto dto = new PaymentInitRequestDto(roomId, postId, tranAmt);
 
             Member toMember = Member.builder()
-                    .id(2L)
+                    .id(toMemberId)
                     .email("test1@test.com")
                     .nickName("테스트2")
                     .balance(INITIAL_BALANCE)
@@ -122,13 +128,12 @@ class PaymentServiceUnitTest {
             ReflectionTestUtils.setField(targetPost, "id", postId);
 
             given(postService.getPostOrThrow(postId)).willReturn(targetPost);
+            given(chatMessageService.create(eq(roomId), eq(toMemberId), contains("결제 링크입니다!")))
+                    .willReturn(mock(ChatMessageResponseDto.class));
             //when
-            String result = paymentService.requestPayment(dto);
-            //then
-            String[] results = result.split("_");
-            assertThat(results.length).isEqualTo(3);
-            assertThat(Long.parseLong(results[1])).isEqualTo(dto.amount());
-            assertThat(Long.parseLong(results[2])).isEqualTo(dto.postId());
+            paymentService.requestPayment(toMemberId, dto);
+            // then
+            then(chatMessageService).should(times(1)).create(eq(roomId), eq(toMemberId), contains("결제 링크입니다!"));
         }
     }
 

--- a/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
+++ b/src/test/java/com/ktcloud/daangn/payment/service/PaymentServiceUnitTest.java
@@ -180,7 +180,6 @@ class PaymentServiceUnitTest {
             ReflectionTestUtils.setField(targetPost, "id", postId);
 
             UUID tranSeqNo = UuidCreator.getTimeOrderedEpoch();
-            String tx = tranSeqNo.toString();
 
             PaymentToken paymentToken = new PaymentToken(tranSeqNo,postId,toMemberId,tranAmt, PaymentTokenStatus.PENDING);
             given(memberService.getByIdOrThrowWithLock(fromMemberId)).willReturn(fromMember);
@@ -188,7 +187,7 @@ class PaymentServiceUnitTest {
             given(postService.getPostOrThrowWithLock(postId)).willReturn(targetPost);
             given(paymentTokenRepository.getToken(tranSeqNo)).willReturn(Optional.of(paymentToken));
             //when
-            PaymentResponseDto result = paymentService.confirmPayment(fromMember.getId(), tx);
+            PaymentResponseDto result = paymentService.confirmPayment(fromMember.getId(), tranSeqNo);
             //then
             verify(paymentRepository, times(2)).save(any(PaymentHistory.class));
             assertThat(result.balance()).isEqualTo(fromMember.getBalance());


### PR DESCRIPTION
작업 내용
- Member 결제 시 비관적 Lock 도입
- ID 기준 정렬로 Lock 획득 순서 일관화 (데드락 방지)
- PaymentHistory `(tranSeqNo, type)` 복합 유니크 제약으로 멱등성 보장
- PaymentHistory 타입 Enum 관리
- 동시성 테스트 6종 추가
    - 다수 구매자 → 단일 판매자
    - 단일 구매자 → 다수 판매자
    - 잔액 부족 동시 결제
    - 동일 결제 링크 중복 결제 (멱등성)
    - 상호 결제 데드락 검증
    - 동일 게시물 동시 결제 시 이중 판매 방지 검증
- 검증 직전 `em.clear()` 호출로 stale 데이터 차단

resolve #75 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 데이터 무결성 오류 시 BAD_REQUEST로 응답하고 “필수 값이 누락되었거나 형식이 올바르지 않습니다.” 메시지를 반환하도록 개선

* **개선 사항**
  * 결제 링크 확정/조회 요청에 락 기반 동시성 처리를 적용
  * 결제 이력·거래 토큰을 상태값/UUID 중심으로 정리하고 필수값·중복 방지 조건을 강화
  * 결제 링크 생성 시 roomId 입력 추가, 생성 응답을 “거래 생성 성공”으로 변경
  * 결제 링크 기본 URL을 dev/prod/test 설정으로 관리

* **테스트**
  * 동시성/예외/통합 시나리오를 추가·보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->